### PR TITLE
feat: disc5 concurrent requests

### DIFF
--- a/pkg/eth/table_test.go
+++ b/pkg/eth/table_test.go
@@ -1,0 +1,445 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package eth
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"math/rand"
+	"net"
+	"reflect"
+	"testing"
+	"testing/quick"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
+	"github.com/ethereum/go-ethereum/p2p/netutil"
+)
+
+func TestTable_pingReplace(t *testing.T) {
+	run := func(newNodeResponding, lastInBucketResponding bool) {
+		name := fmt.Sprintf("newNodeResponding=%t/lastInBucketResponding=%t", newNodeResponding, lastInBucketResponding)
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			testPingReplace(t, newNodeResponding, lastInBucketResponding)
+		})
+	}
+
+	run(true, true)
+	run(false, true)
+	run(true, false)
+	run(false, false)
+}
+
+func testPingReplace(t *testing.T, newNodeIsResponding, lastInBucketIsResponding bool) {
+	transport := newPingRecorder()
+	tab, db := newTestTable(transport)
+	defer db.Close()
+	defer tab.close()
+
+	<-tab.initDone
+
+	// Fill up the sender's bucket.
+	pingKey, _ := crypto.HexToECDSA("45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8")
+	pingSender := wrapNode(enode.NewV4(&pingKey.PublicKey, net.IP{127, 0, 0, 1}, 99, 99))
+	last := fillBucket(tab, pingSender)
+
+	// Add the sender as if it just pinged us. Revalidate should replace the last node in
+	// its bucket if it is unresponsive. Revalidate again to ensure that
+	transport.dead[last.ID()] = !lastInBucketIsResponding
+	transport.dead[pingSender.ID()] = !newNodeIsResponding
+	tab.addSeenNode(pingSender)
+	tab.doRevalidate(make(chan struct{}, 1))
+	tab.doRevalidate(make(chan struct{}, 1))
+
+	if !transport.pinged[last.ID()] {
+		// Oldest node in bucket is pinged to see whether it is still alive.
+		t.Error("table did not ping last node in bucket")
+	}
+
+	tab.mutex.Lock()
+	defer tab.mutex.Unlock()
+	wantSize := bucketSize
+	if !lastInBucketIsResponding && !newNodeIsResponding {
+		wantSize--
+	}
+	if l := len(tab.bucket(pingSender.ID()).entries); l != wantSize {
+		t.Errorf("wrong bucket size after bond: got %d, want %d", l, wantSize)
+	}
+	if found := contains(tab.bucket(pingSender.ID()).entries, last.ID()); found != lastInBucketIsResponding {
+		t.Errorf("last entry found: %t, want: %t", found, lastInBucketIsResponding)
+	}
+	wantNewEntry := newNodeIsResponding && !lastInBucketIsResponding
+	if found := contains(tab.bucket(pingSender.ID()).entries, pingSender.ID()); found != wantNewEntry {
+		t.Errorf("new entry found: %t, want: %t", found, wantNewEntry)
+	}
+}
+
+func TestBucket_bumpNoDuplicates(t *testing.T) {
+	t.Parallel()
+	cfg := &quick.Config{
+		MaxCount: 1000,
+		Rand:     rand.New(rand.NewSource(time.Now().Unix())),
+		Values: func(args []reflect.Value, rand *rand.Rand) {
+			// generate a random list of nodes. this will be the content of the bucket.
+			n := rand.Intn(bucketSize-1) + 1
+			nodes := make([]*node, n)
+			for i := range nodes {
+				nodes[i] = nodeAtDistance(enode.ID{}, 200, intIP(200))
+			}
+			args[0] = reflect.ValueOf(nodes)
+			// generate random bump positions.
+			bumps := make([]int, rand.Intn(100))
+			for i := range bumps {
+				bumps[i] = rand.Intn(len(nodes))
+			}
+			args[1] = reflect.ValueOf(bumps)
+		},
+	}
+
+	prop := func(nodes []*node, bumps []int) (ok bool) {
+		tab, db := newTestTable(newPingRecorder())
+		defer db.Close()
+		defer tab.close()
+
+		b := &bucket{entries: make([]*node, len(nodes))}
+		copy(b.entries, nodes)
+		for i, pos := range bumps {
+			tab.bumpInBucket(b, b.entries[pos])
+			if hasDuplicates(b.entries) {
+				t.Logf("bucket has duplicates after %d/%d bumps:", i+1, len(bumps))
+				for _, n := range b.entries {
+					t.Logf("  %p", n)
+				}
+				return false
+			}
+		}
+		checkIPLimitInvariant(t, tab)
+		return true
+	}
+	if err := quick.Check(prop, cfg); err != nil {
+		t.Error(err)
+	}
+}
+
+// This checks that the table-wide IP limit is applied correctly.
+func TestTable_IPLimit(t *testing.T) {
+	transport := newPingRecorder()
+	tab, db := newTestTable(transport)
+	defer db.Close()
+	defer tab.close()
+
+	for i := 0; i < tableIPLimit+1; i++ {
+		n := nodeAtDistance(tab.self().ID(), i, net.IP{172, 0, 1, byte(i)})
+		tab.addSeenNode(n)
+	}
+	if tab.len() > tableIPLimit {
+		t.Errorf("too many nodes in table")
+	}
+	checkIPLimitInvariant(t, tab)
+}
+
+// This checks that the per-bucket IP limit is applied correctly.
+func TestTable_BucketIPLimit(t *testing.T) {
+	transport := newPingRecorder()
+	tab, db := newTestTable(transport)
+	defer db.Close()
+	defer tab.close()
+
+	d := 3
+	for i := 0; i < bucketIPLimit+1; i++ {
+		n := nodeAtDistance(tab.self().ID(), d, net.IP{172, 0, 1, byte(i)})
+		tab.addSeenNode(n)
+	}
+	if tab.len() > bucketIPLimit {
+		t.Errorf("too many nodes in table")
+	}
+	checkIPLimitInvariant(t, tab)
+}
+
+// checkIPLimitInvariant checks that ip limit sets contain an entry for every
+// node in the table and no extra entries.
+func checkIPLimitInvariant(t *testing.T, tab *Table) {
+	t.Helper()
+
+	tabset := netutil.DistinctNetSet{Subnet: tableSubnet, Limit: tableIPLimit}
+	for _, b := range tab.buckets {
+		for _, n := range b.entries {
+			tabset.Add(n.IP())
+		}
+	}
+	if tabset.String() != tab.ips.String() {
+		t.Errorf("table IP set is incorrect:\nhave: %v\nwant: %v", tab.ips, tabset)
+	}
+}
+
+func TestTable_findnodeByID(t *testing.T) {
+	t.Parallel()
+
+	test := func(test *closeTest) bool {
+		// for any node table, Target and N
+		transport := newPingRecorder()
+		tab, db := newTestTable(transport)
+		defer db.Close()
+		defer tab.close()
+		fillTable(tab, test.All)
+
+		// check that closest(Target, N) returns nodes
+		result := tab.findnodeByID(test.Target, test.N, false).entries
+		if hasDuplicates(result) {
+			t.Errorf("result contains duplicates")
+			return false
+		}
+		if !sortedByDistanceTo(test.Target, result) {
+			t.Errorf("result is not sorted by distance to target")
+			return false
+		}
+
+		// check that the number of results is min(N, tablen)
+		wantN := test.N
+		if tlen := tab.len(); tlen < test.N {
+			wantN = tlen
+		}
+		if len(result) != wantN {
+			t.Errorf("wrong number of nodes: got %d, want %d", len(result), wantN)
+			return false
+		} else if len(result) == 0 {
+			return true // no need to check distance
+		}
+
+		// check that the result nodes have minimum distance to target.
+		for _, b := range tab.buckets {
+			for _, n := range b.entries {
+				if contains(result, n.ID()) {
+					continue // don't run the check below for nodes in result
+				}
+				farthestResult := result[len(result)-1].ID()
+				if enode.DistCmp(test.Target, n.ID(), farthestResult) < 0 {
+					t.Errorf("table contains node that is closer to target but it's not in result")
+					t.Logf("  Target:          %v", test.Target)
+					t.Logf("  Farthest Result: %v", farthestResult)
+					t.Logf("  ID:              %v", n.ID())
+					return false
+				}
+			}
+		}
+		return true
+	}
+	if err := quick.Check(test, quickcfg()); err != nil {
+		t.Error(err)
+	}
+}
+
+type closeTest struct {
+	Self   enode.ID
+	Target enode.ID
+	All    []*node
+	N      int
+}
+
+func (*closeTest) Generate(rand *rand.Rand, size int) reflect.Value {
+	t := &closeTest{
+		Self:   gen(enode.ID{}, rand).(enode.ID),
+		Target: gen(enode.ID{}, rand).(enode.ID),
+		N:      rand.Intn(bucketSize),
+	}
+	for _, id := range gen([]enode.ID{}, rand).([]enode.ID) {
+		r := new(enr.Record)
+		r.Set(enr.IP(genIP(rand)))
+		n := wrapNode(enode.SignNull(r, id))
+		n.livenessChecks = 1
+		t.All = append(t.All, n)
+	}
+	return reflect.ValueOf(t)
+}
+
+func TestTable_addVerifiedNode(t *testing.T) {
+	tab, db := newTestTable(newPingRecorder())
+	<-tab.initDone
+	defer db.Close()
+	defer tab.close()
+
+	// Insert two nodes.
+	n1 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 1})
+	n2 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 2})
+	tab.addSeenNode(n1)
+	tab.addSeenNode(n2)
+
+	// Verify bucket content:
+	bcontent := []*node{n1, n2}
+	if !reflect.DeepEqual(tab.bucket(n1.ID()).entries, bcontent) {
+		t.Fatalf("wrong bucket content: %v", tab.bucket(n1.ID()).entries)
+	}
+
+	// Add a changed version of n2.
+	newrec := n2.Record()
+	newrec.Set(enr.IP{99, 99, 99, 99})
+	newn2 := wrapNode(enode.SignNull(newrec, n2.ID()))
+	tab.addVerifiedNode(newn2)
+
+	// Check that bucket is updated correctly.
+	newBcontent := []*node{newn2, n1}
+	if !reflect.DeepEqual(tab.bucket(n1.ID()).entries, newBcontent) {
+		t.Fatalf("wrong bucket content after update: %v", tab.bucket(n1.ID()).entries)
+	}
+	checkIPLimitInvariant(t, tab)
+}
+
+func TestTable_addSeenNode(t *testing.T) {
+	tab, db := newTestTable(newPingRecorder())
+	<-tab.initDone
+	defer db.Close()
+	defer tab.close()
+
+	// Insert two nodes.
+	n1 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 1})
+	n2 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 2})
+	tab.addSeenNode(n1)
+	tab.addSeenNode(n2)
+
+	// Verify bucket content:
+	bcontent := []*node{n1, n2}
+	if !reflect.DeepEqual(tab.bucket(n1.ID()).entries, bcontent) {
+		t.Fatalf("wrong bucket content: %v", tab.bucket(n1.ID()).entries)
+	}
+
+	// Add a changed version of n2.
+	newrec := n2.Record()
+	newrec.Set(enr.IP{99, 99, 99, 99})
+	newn2 := wrapNode(enode.SignNull(newrec, n2.ID()))
+	tab.addSeenNode(newn2)
+
+	// Check that bucket content is unchanged.
+	if !reflect.DeepEqual(tab.bucket(n1.ID()).entries, bcontent) {
+		t.Fatalf("wrong bucket content after update: %v", tab.bucket(n1.ID()).entries)
+	}
+	checkIPLimitInvariant(t, tab)
+}
+
+// This test checks that ENR updates happen during revalidation. If a node in the table
+// announces a new sequence number, the new record should be pulled.
+func TestTable_revalidateSyncRecord(t *testing.T) {
+	transport := newPingRecorder()
+	tab, db := newTestTable(transport)
+	<-tab.initDone
+	defer db.Close()
+	defer tab.close()
+
+	// Insert a node.
+	var r enr.Record
+	r.Set(enr.IP(net.IP{127, 0, 0, 1}))
+	id := enode.ID{1}
+	n1 := wrapNode(enode.SignNull(&r, id))
+	tab.addSeenNode(n1)
+
+	// Update the node record.
+	r.Set(enr.WithEntry("foo", "bar"))
+	n2 := enode.SignNull(&r, id)
+	transport.updateRecord(n2)
+
+	tab.doRevalidate(make(chan struct{}, 1))
+	intable := tab.getNode(id)
+	if !reflect.DeepEqual(intable, n2) {
+		t.Fatalf("table contains old record with seq %d, want seq %d", intable.Seq(), n2.Seq())
+	}
+}
+
+func TestNodesPush(t *testing.T) {
+	var target enode.ID
+	n1 := nodeAtDistance(target, 255, intIP(1))
+	n2 := nodeAtDistance(target, 254, intIP(2))
+	n3 := nodeAtDistance(target, 253, intIP(3))
+	perm := [][]*node{
+		{n3, n2, n1},
+		{n3, n1, n2},
+		{n2, n3, n1},
+		{n2, n1, n3},
+		{n1, n3, n2},
+		{n1, n2, n3},
+	}
+
+	// Insert all permutations into lists with size limit 3.
+	for _, nodes := range perm {
+		list := nodesByDistance{target: target}
+		for _, n := range nodes {
+			list.push(n, 3)
+		}
+		if !slicesEqual(list.entries, perm[0], nodeIDEqual) {
+			t.Fatal("not equal")
+		}
+	}
+
+	// Insert all permutations into lists with size limit 2.
+	for _, nodes := range perm {
+		list := nodesByDistance{target: target}
+		for _, n := range nodes {
+			list.push(n, 2)
+		}
+		if !slicesEqual(list.entries, perm[0][:2], nodeIDEqual) {
+			t.Fatal("not equal")
+		}
+	}
+}
+
+func nodeIDEqual(n1, n2 *node) bool {
+	return n1.ID() == n2.ID()
+}
+
+func slicesEqual[T any](s1, s2 []T, check func(e1, e2 T) bool) bool {
+	if len(s1) != len(s2) {
+		return false
+	}
+	for i := range s1 {
+		if !check(s1[i], s2[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// gen wraps quick.Value so it's easier to use.
+// it generates a random value of the given value's type.
+func gen(typ interface{}, rand *rand.Rand) interface{} {
+	v, ok := quick.Value(reflect.TypeOf(typ), rand)
+	if !ok {
+		panic(fmt.Sprintf("couldn't generate random value of type %T", typ))
+	}
+	return v.Interface()
+}
+
+func genIP(rand *rand.Rand) net.IP {
+	ip := make(net.IP, 4)
+	rand.Read(ip)
+	return ip
+}
+
+func quickcfg() *quick.Config {
+	return &quick.Config{
+		MaxCount: 5000,
+		Rand:     rand.New(rand.NewSource(time.Now().Unix())),
+	}
+}
+
+func newkey() *ecdsa.PrivateKey {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		panic("couldn't generate key: " + err.Error())
+	}
+	return key
+}

--- a/pkg/eth/table_util_test.go
+++ b/pkg/eth/table_util_test.go
@@ -1,0 +1,255 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package eth
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/rand"
+	"net"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
+	"golang.org/x/exp/slices"
+)
+
+var nullNode *enode.Node
+
+func init() {
+	var r enr.Record
+	r.Set(enr.IP{0, 0, 0, 0})
+	nullNode = enode.SignNull(&r, enode.ID{})
+}
+
+func newTestTable(t transport) (*Table, *enode.DB) {
+	cfg := Config{}
+	db, _ := enode.OpenDB("")
+	tab, _ := newTable(t, db, cfg)
+	go tab.loop()
+	return tab, db
+}
+
+// nodeAtDistance creates a node for which enode.LogDist(base, n.id) == ld.
+func nodeAtDistance(base enode.ID, ld int, ip net.IP) *node {
+	var r enr.Record
+	r.Set(enr.IP(ip))
+	r.Set(enr.UDP(30303))
+	return wrapNode(enode.SignNull(&r, idAtDistance(base, ld)))
+}
+
+// nodesAtDistance creates n nodes for which enode.LogDist(base, node.ID()) == ld.
+func nodesAtDistance(base enode.ID, ld int, n int) []*enode.Node {
+	results := make([]*enode.Node, n)
+	for i := range results {
+		results[i] = unwrapNode(nodeAtDistance(base, ld, intIP(i)))
+	}
+	return results
+}
+
+func nodesToRecords(nodes []*enode.Node) []*enr.Record {
+	records := make([]*enr.Record, len(nodes))
+	for i := range nodes {
+		records[i] = nodes[i].Record()
+	}
+	return records
+}
+
+// idAtDistance returns a random hash such that enode.LogDist(a, b) == n
+func idAtDistance(a enode.ID, n int) (b enode.ID) {
+	if n == 0 {
+		return a
+	}
+	// flip bit at position n, fill the rest with random bits
+	b = a
+	pos := len(a) - n/8 - 1
+	bit := byte(0x01) << (byte(n%8) - 1)
+	if bit == 0 {
+		pos++
+		bit = 0x80
+	}
+	b[pos] = a[pos]&^bit | ^a[pos]&bit // TODO: randomize end bits
+	for i := pos + 1; i < len(a); i++ {
+		b[i] = byte(rand.Intn(255))
+	}
+	return b
+}
+
+func intIP(i int) net.IP {
+	return net.IP{byte(i), 0, 2, byte(i)}
+}
+
+// fillBucket inserts nodes into the given bucket until it is full.
+func fillBucket(tab *Table, n *node) (last *node) {
+	ld := enode.LogDist(tab.self().ID(), n.ID())
+	b := tab.bucket(n.ID())
+	for len(b.entries) < bucketSize {
+		b.entries = append(b.entries, nodeAtDistance(tab.self().ID(), ld, intIP(ld)))
+	}
+	return b.entries[bucketSize-1]
+}
+
+// fillTable adds nodes the table to the end of their corresponding bucket
+// if the bucket is not full. The caller must not hold tab.mutex.
+func fillTable(tab *Table, nodes []*node) {
+	for _, n := range nodes {
+		tab.addSeenNode(n)
+	}
+}
+
+type pingRecorder struct {
+	mu           sync.Mutex
+	dead, pinged map[enode.ID]bool
+	records      map[enode.ID]*enode.Node
+	n            *enode.Node
+}
+
+func newPingRecorder() *pingRecorder {
+	var r enr.Record
+	r.Set(enr.IP{0, 0, 0, 0})
+	n := enode.SignNull(&r, enode.ID{})
+
+	return &pingRecorder{
+		dead:    make(map[enode.ID]bool),
+		pinged:  make(map[enode.ID]bool),
+		records: make(map[enode.ID]*enode.Node),
+		n:       n,
+	}
+}
+
+// updateRecord updates a node record. Future calls to ping and
+// RequestENR will return this record.
+func (t *pingRecorder) updateRecord(n *enode.Node) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.records[n.ID()] = n
+}
+
+// Stubs to satisfy the transport interface.
+func (t *pingRecorder) Self() *enode.Node           { return nullNode }
+func (t *pingRecorder) lookupSelf() []*enode.Node   { return nil }
+func (t *pingRecorder) lookupRandom() []*enode.Node { return nil }
+
+// ping simulates a ping request.
+func (t *pingRecorder) ping(n *enode.Node) (seq uint64, err error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.pinged[n.ID()] = true
+	if t.dead[n.ID()] {
+		return 0, ErrTimeout
+	}
+	if t.records[n.ID()] != nil {
+		seq = t.records[n.ID()].Seq()
+	}
+	return seq, nil
+}
+
+// RequestENR simulates an ENR request.
+func (t *pingRecorder) RequestENR(n *enode.Node) (*enode.Node, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.dead[n.ID()] || t.records[n.ID()] == nil {
+		return nil, ErrTimeout
+	}
+	return t.records[n.ID()], nil
+}
+
+func hasDuplicates(slice []*node) bool {
+	seen := make(map[enode.ID]bool, len(slice))
+	for i, e := range slice {
+		if e == nil {
+			panic(fmt.Sprintf("nil *Node at %d", i))
+		}
+		if seen[e.ID()] {
+			return true
+		}
+		seen[e.ID()] = true
+	}
+	return false
+}
+
+// checkNodesEqual checks whether the two given node lists contain the same nodes.
+func checkNodesEqual(got, want []*enode.Node) error {
+	if len(got) == len(want) {
+		for i := range got {
+			if !nodeEqual(got[i], want[i]) {
+				goto NotEqual
+			}
+		}
+	}
+	return nil
+
+NotEqual:
+	output := new(bytes.Buffer)
+	fmt.Fprintf(output, "got %d nodes:\n", len(got))
+	for _, n := range got {
+		fmt.Fprintf(output, "  %v %v\n", n.ID(), n)
+	}
+	fmt.Fprintf(output, "want %d:\n", len(want))
+	for _, n := range want {
+		fmt.Fprintf(output, "  %v %v\n", n.ID(), n)
+	}
+	return errors.New(output.String())
+}
+
+func nodeEqual(n1 *enode.Node, n2 *enode.Node) bool {
+	return n1.ID() == n2.ID() && n1.IP().Equal(n2.IP())
+}
+
+func sortByID(nodes []*enode.Node) {
+	slices.SortFunc(nodes, func(a, b *enode.Node) int {
+		return bytes.Compare(a.ID().Bytes(), b.ID().Bytes())
+	})
+}
+
+func sortedByDistanceTo(distbase enode.ID, slice []*node) bool {
+	return slices.IsSortedFunc(slice, func(a, b *node) int {
+		return enode.DistCmp(distbase, a.ID(), b.ID())
+	})
+}
+
+// hexEncPrivkey decodes h as a private key.
+func hexEncPrivkey(h string) *ecdsa.PrivateKey {
+	b, err := hex.DecodeString(h)
+	if err != nil {
+		panic(err)
+	}
+	key, err := crypto.ToECDSA(b)
+	if err != nil {
+		panic(err)
+	}
+	return key
+}
+
+// hexEncPubkey decodes h as a public key.
+func hexEncPubkey(h string) (ret encPubkey) {
+	b, err := hex.DecodeString(h)
+	if err != nil {
+		panic(err)
+	}
+	if len(b) != len(ret) {
+		panic("invalid length")
+	}
+	copy(ret[:], b)
+	return ret
+}

--- a/pkg/eth/testlog.go
+++ b/pkg/eth/testlog.go
@@ -1,0 +1,142 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package testlog provides a log handler for unit tests.
+package eth
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// Handler returns a log handler which logs to the unit test log of t.
+func Handler(t *testing.T, level log.Lvl) log.Handler {
+	return log.LvlFilterHandler(level, &handler{t, log.TerminalFormat(false)})
+}
+
+type handler struct {
+	t   *testing.T
+	fmt log.Format
+}
+
+func (h *handler) Log(r *log.Record) error {
+	h.t.Logf("%s", h.fmt.Format(r))
+	return nil
+}
+
+// logger implements log.Logger such that all output goes to the unit test log via
+// t.Logf(). All methods in between logger.Trace, logger.Debug, etc. are marked as test
+// helpers, so the file and line number in unit test output correspond to the call site
+// which emitted the log message.
+type logger struct {
+	t  *testing.T
+	l  log.Logger
+	mu *sync.Mutex
+	h  *bufHandler
+}
+
+type bufHandler struct {
+	buf []*log.Record
+	fmt log.Format
+}
+
+func (h *bufHandler) Log(r *log.Record) error {
+	h.buf = append(h.buf, r)
+	return nil
+}
+
+// Logger returns a logger which logs to the unit test log of t.
+func Logger(t *testing.T, level log.Lvl) log.Logger {
+	l := &logger{
+		t:  t,
+		l:  log.New(),
+		mu: new(sync.Mutex),
+		h:  &bufHandler{fmt: log.TerminalFormat(false)},
+	}
+	l.l.SetHandler(log.LvlFilterHandler(level, l.h))
+	return l
+}
+
+func (l *logger) Trace(msg string, ctx ...interface{}) {
+	l.t.Helper()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.l.Trace(msg, ctx...)
+	l.flush()
+}
+
+func (l *logger) Debug(msg string, ctx ...interface{}) {
+	l.t.Helper()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.l.Debug(msg, ctx...)
+	l.flush()
+}
+
+func (l *logger) Info(msg string, ctx ...interface{}) {
+	l.t.Helper()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.l.Info(msg, ctx...)
+	l.flush()
+}
+
+func (l *logger) Warn(msg string, ctx ...interface{}) {
+	l.t.Helper()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.l.Warn(msg, ctx...)
+	l.flush()
+}
+
+func (l *logger) Error(msg string, ctx ...interface{}) {
+	l.t.Helper()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.l.Error(msg, ctx...)
+	l.flush()
+}
+
+func (l *logger) Crit(msg string, ctx ...interface{}) {
+	l.t.Helper()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.l.Crit(msg, ctx...)
+	l.flush()
+}
+
+func (l *logger) New(ctx ...interface{}) log.Logger {
+	return &logger{l.t, l.l.New(ctx...), l.mu, l.h}
+}
+
+func (l *logger) GetHandler() log.Handler {
+	return l.l.GetHandler()
+}
+
+func (l *logger) SetHandler(h log.Handler) {
+	l.l.SetHandler(h)
+}
+
+// flush writes all buffered messages and clears the buffer.
+func (l *logger) flush() {
+	l.t.Helper()
+	for _, r := range l.h.buf {
+		l.t.Logf("%s", l.h.fmt.Format(r))
+	}
+	l.h.buf = nil
+}

--- a/pkg/eth/v4_lookup_test.go
+++ b/pkg/eth/v4_lookup_test.go
@@ -1,0 +1,347 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package eth
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/p2p/discover/v4wire"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
+	"golang.org/x/exp/slices"
+)
+
+func TestUDPv4_Lookup(t *testing.T) {
+	t.Parallel()
+	test := newUDPTest(t)
+
+	// Lookup on empty table returns no nodes.
+	targetKey, _ := decodePubkey(crypto.S256(), lookupTestnet.target[:])
+	if results := test.udp.LookupPubkey(targetKey); len(results) > 0 {
+		t.Fatalf("lookup on empty table returned %d results: %#v", len(results), results)
+	}
+
+	// Seed table with initial node.
+	fillTable(test.table, []*node{wrapNode(lookupTestnet.node(256, 0))})
+
+	// Start the lookup.
+	resultC := make(chan []*enode.Node, 1)
+	go func() {
+		resultC <- test.udp.LookupPubkey(targetKey)
+		test.close()
+	}()
+
+	// Answer lookup packets.
+	serveTestnet(test, lookupTestnet)
+
+	// Verify result nodes.
+	results := <-resultC
+	t.Logf("results:")
+	for _, e := range results {
+		t.Logf("  ld=%d, %x", enode.LogDist(lookupTestnet.target.id(), e.ID()), e.ID().Bytes())
+	}
+	if len(results) != bucketSize {
+		t.Errorf("wrong number of results: got %d, want %d", len(results), bucketSize)
+	}
+	checkLookupResults(t, lookupTestnet, results)
+}
+
+func TestUDPv4_LookupIterator(t *testing.T) {
+	t.Parallel()
+	test := newUDPTest(t)
+	defer test.close()
+
+	// Seed table with initial nodes.
+	bootnodes := make([]*node, len(lookupTestnet.dists[256]))
+	for i := range lookupTestnet.dists[256] {
+		bootnodes[i] = wrapNode(lookupTestnet.node(256, i))
+	}
+	fillTable(test.table, bootnodes)
+	go serveTestnet(test, lookupTestnet)
+
+	// Create the iterator and collect the nodes it yields.
+	iter := test.udp.RandomNodes()
+	seen := make(map[enode.ID]*enode.Node)
+	for limit := lookupTestnet.len(); iter.Next() && len(seen) < limit; {
+		seen[iter.Node().ID()] = iter.Node()
+	}
+	iter.Close()
+
+	// Check that all nodes in lookupTestnet were seen by the iterator.
+	results := make([]*enode.Node, 0, len(seen))
+	for _, n := range seen {
+		results = append(results, n)
+	}
+	sortByID(results)
+	want := lookupTestnet.nodes()
+	if err := checkNodesEqual(results, want); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestUDPv4_LookupIteratorClose checks that lookupIterator ends when its Close
+// method is called.
+func TestUDPv4_LookupIteratorClose(t *testing.T) {
+	t.Parallel()
+	test := newUDPTest(t)
+	defer test.close()
+
+	// Seed table with initial nodes.
+	bootnodes := make([]*node, len(lookupTestnet.dists[256]))
+	for i := range lookupTestnet.dists[256] {
+		bootnodes[i] = wrapNode(lookupTestnet.node(256, i))
+	}
+	fillTable(test.table, bootnodes)
+	go serveTestnet(test, lookupTestnet)
+
+	it := test.udp.RandomNodes()
+	if ok := it.Next(); !ok || it.Node() == nil {
+		t.Fatalf("iterator didn't return any node")
+	}
+
+	it.Close()
+
+	ncalls := 0
+	for ; ncalls < 100 && it.Next(); ncalls++ {
+		if it.Node() == nil {
+			t.Error("iterator returned Node() == nil node after Next() == true")
+		}
+	}
+	t.Logf("iterator returned %d nodes after close", ncalls)
+	if it.Next() {
+		t.Errorf("Next() == true after close and %d more calls", ncalls)
+	}
+	if n := it.Node(); n != nil {
+		t.Errorf("iterator returned non-nil node after close and %d more calls", ncalls)
+	}
+}
+
+func serveTestnet(test *udpTest, testnet *preminedTestnet) {
+	for done := false; !done; {
+		done = test.waitPacketOut(func(p v4wire.Packet, to *net.UDPAddr, hash []byte) {
+			n, key := testnet.nodeByAddr(to)
+			switch p.(type) {
+			case *v4wire.Ping:
+				test.packetInFrom(nil, key, to, &v4wire.Pong{Expiration: futureExp, ReplyTok: hash})
+			case *v4wire.Findnode:
+				dist := enode.LogDist(n.ID(), testnet.target.id())
+				nodes := testnet.nodesAtDistance(dist - 1)
+				test.packetInFrom(nil, key, to, &v4wire.Neighbors{Expiration: futureExp, Nodes: nodes})
+			}
+		})
+	}
+}
+
+// checkLookupResults verifies that the results of a lookup are the closest nodes to
+// the testnet's target.
+func checkLookupResults(t *testing.T, tn *preminedTestnet, results []*enode.Node) {
+	t.Helper()
+	t.Logf("results:")
+	for _, e := range results {
+		t.Logf("  ld=%d, %x", enode.LogDist(tn.target.id(), e.ID()), e.ID().Bytes())
+	}
+	if hasDuplicates(wrapNodes(results)) {
+		t.Errorf("result set contains duplicate entries")
+	}
+	if !sortedByDistanceTo(tn.target.id(), wrapNodes(results)) {
+		t.Errorf("result set not sorted by distance to target")
+	}
+	wantNodes := tn.closest(len(results))
+	if err := checkNodesEqual(results, wantNodes); err != nil {
+		t.Error(err)
+	}
+}
+
+// This is the test network for the Lookup test.
+// The nodes were obtained by running lookupTestnet.mine with a random NodeID as target.
+var lookupTestnet = &preminedTestnet{
+	target: hexEncPubkey("5d485bdcbe9bc89314a10ae9231e429d33853e3a8fa2af39f5f827370a2e4185e344ace5d16237491dad41f278f1d3785210d29ace76cd627b9147ee340b1125"),
+	dists: [257][]*ecdsa.PrivateKey{
+		251: {
+			hexEncPrivkey("29738ba0c1a4397d6a65f292eee07f02df8e58d41594ba2be3cf84ce0fc58169"),
+			hexEncPrivkey("511b1686e4e58a917f7f848e9bf5539d206a68f5ad6b54b552c2399fe7d174ae"),
+			hexEncPrivkey("d09e5eaeec0fd596236faed210e55ef45112409a5aa7f3276d26646080dcfaeb"),
+			hexEncPrivkey("c1e20dbbf0d530e50573bd0a260b32ec15eb9190032b4633d44834afc8afe578"),
+			hexEncPrivkey("ed5f38f5702d92d306143e5d9154fb21819777da39af325ea359f453d179e80b"),
+		},
+		252: {
+			hexEncPrivkey("1c9b1cafbec00848d2c174b858219914b42a7d5c9359b1ca03fd650e8239ae94"),
+			hexEncPrivkey("e0e1e8db4a6f13c1ffdd3e96b72fa7012293ced187c9dcdcb9ba2af37a46fa10"),
+			hexEncPrivkey("3d53823e0a0295cb09f3e11d16c1b44d07dd37cec6f739b8df3a590189fe9fb9"),
+		},
+		253: {
+			hexEncPrivkey("2d0511ae9bf590166597eeab86b6f27b1ab761761eaea8965487b162f8703847"),
+			hexEncPrivkey("6cfbd7b8503073fc3dbdb746a7c672571648d3bd15197ccf7f7fef3d904f53a2"),
+			hexEncPrivkey("a30599b12827b69120633f15b98a7f6bc9fc2e9a0fd6ae2ebb767c0e64d743ab"),
+			hexEncPrivkey("14a98db9b46a831d67eff29f3b85b1b485bb12ae9796aea98d91be3dc78d8a91"),
+			hexEncPrivkey("2369ff1fc1ff8ca7d20b17e2673adc3365c3674377f21c5d9dafaff21fe12e24"),
+			hexEncPrivkey("9ae91101d6b5048607f41ec0f690ef5d09507928aded2410aabd9237aa2727d7"),
+			hexEncPrivkey("05e3c59090a3fd1ae697c09c574a36fcf9bedd0afa8fe3946f21117319ca4973"),
+			hexEncPrivkey("06f31c5ea632658f718a91a1b1b9ae4b7549d7b3bc61cbc2be5f4a439039f3ad"),
+		},
+		254: {
+			hexEncPrivkey("dec742079ec00ff4ec1284d7905bc3de2366f67a0769431fd16f80fd68c58a7c"),
+			hexEncPrivkey("ff02c8861fa12fbd129d2a95ea663492ef9c1e51de19dcfbbfe1c59894a28d2b"),
+			hexEncPrivkey("4dded9e4eefcbce4262be4fd9e8a773670ab0b5f448f286ec97dfc8cf681444a"),
+			hexEncPrivkey("750d931e2a8baa2c9268cb46b7cd851f4198018bed22f4dceb09dd334a2395f6"),
+			hexEncPrivkey("ce1435a956a98ffec484cd11489c4f165cf1606819ab6b521cee440f0c677e9e"),
+			hexEncPrivkey("996e7f8d1638be92d7328b4770f47e5420fc4bafecb4324fd33b1f5d9f403a75"),
+			hexEncPrivkey("ebdc44e77a6cc0eb622e58cf3bb903c3da4c91ca75b447b0168505d8fc308b9c"),
+			hexEncPrivkey("46bd1eddcf6431bea66fc19ebc45df191c1c7d6ed552dcdc7392885009c322f0"),
+		},
+		255: {
+			hexEncPrivkey("da8645f90826e57228d9ea72aff84500060ad111a5d62e4af831ed8e4b5acfb8"),
+			hexEncPrivkey("3c944c5d9af51d4c1d43f5d0f3a1a7ef65d5e82744d669b58b5fed242941a566"),
+			hexEncPrivkey("5ebcde76f1d579eebf6e43b0ffe9157e65ffaa391175d5b9aa988f47df3e33da"),
+			hexEncPrivkey("97f78253a7d1d796e4eaabce721febcc4550dd68fb11cc818378ba807a2cb7de"),
+			hexEncPrivkey("a38cd7dc9b4079d1c0406afd0fdb1165c285f2c44f946eca96fc67772c988c7d"),
+			hexEncPrivkey("d64cbb3ffdf712c372b7a22a176308ef8f91861398d5dbaf326fd89c6eaeef1c"),
+			hexEncPrivkey("d269609743ef29d6446e3355ec647e38d919c82a4eb5837e442efd7f4218944f"),
+			hexEncPrivkey("d8f7bcc4a530efde1d143717007179e0d9ace405ddaaf151c4d863753b7fd64c"),
+		},
+		256: {
+			hexEncPrivkey("8c5b422155d33ea8e9d46f71d1ad3e7b24cb40051413ffa1a81cff613d243ba9"),
+			hexEncPrivkey("937b1af801def4e8f5a3a8bd225a8bcff1db764e41d3e177f2e9376e8dd87233"),
+			hexEncPrivkey("120260dce739b6f71f171da6f65bc361b5fad51db74cf02d3e973347819a6518"),
+			hexEncPrivkey("1fa56cf25d4b46c2bf94e82355aa631717b63190785ac6bae545a88aadc304a9"),
+			hexEncPrivkey("3c38c503c0376f9b4adcbe935d5f4b890391741c764f61b03cd4d0d42deae002"),
+			hexEncPrivkey("3a54af3e9fa162bc8623cdf3e5d9b70bf30ade1d54cc3abea8659aba6cff471f"),
+			hexEncPrivkey("6799a02ea1999aefdcbcc4d3ff9544478be7365a328d0d0f37c26bd95ade0cda"),
+			hexEncPrivkey("e24a7bc9051058f918646b0f6e3d16884b2a55a15553b89bab910d55ebc36116"),
+		},
+	},
+}
+
+type preminedTestnet struct {
+	target encPubkey
+	dists  [HashBits + 1][]*ecdsa.PrivateKey
+}
+
+func (tn *preminedTestnet) len() int {
+	n := 0
+	for _, keys := range tn.dists {
+		n += len(keys)
+	}
+	return n
+}
+
+func (tn *preminedTestnet) nodes() []*enode.Node {
+	result := make([]*enode.Node, 0, tn.len())
+	for dist, keys := range tn.dists {
+		for index := range keys {
+			result = append(result, tn.node(dist, index))
+		}
+	}
+	sortByID(result)
+	return result
+}
+
+func (tn *preminedTestnet) node(dist, index int) *enode.Node {
+	key := tn.dists[dist][index]
+	rec := new(enr.Record)
+	rec.Set(enr.IP{127, byte(dist >> 8), byte(dist), byte(index)})
+	rec.Set(enr.UDP(5000))
+	enode.SignV4(rec, key)
+	n, _ := enode.New(enode.ValidSchemes, rec)
+	return n
+}
+
+func (tn *preminedTestnet) nodeByAddr(addr *net.UDPAddr) (*enode.Node, *ecdsa.PrivateKey) {
+	dist := int(addr.IP[1])<<8 + int(addr.IP[2])
+	index := int(addr.IP[3])
+	key := tn.dists[dist][index]
+	return tn.node(dist, index), key
+}
+
+func (tn *preminedTestnet) nodesAtDistance(dist int) []v4wire.Node {
+	result := make([]v4wire.Node, len(tn.dists[dist]))
+	for i := range result {
+		result[i] = nodeToRPC(wrapNode(tn.node(dist, i)))
+	}
+	return result
+}
+
+func (tn *preminedTestnet) neighborsAtDistances(base *enode.Node, distances []uint, elems int) []*enode.Node {
+	var result []*enode.Node
+	for d := range lookupTestnet.dists {
+		for i := range lookupTestnet.dists[d] {
+			n := lookupTestnet.node(d, i)
+			d := enode.LogDist(base.ID(), n.ID())
+			if containsUint(uint(d), distances) {
+				result = append(result, n)
+				if len(result) >= elems {
+					return result
+				}
+			}
+		}
+	}
+	return result
+}
+
+func (tn *preminedTestnet) closest(n int) (nodes []*enode.Node) {
+	for d := range tn.dists {
+		for i := range tn.dists[d] {
+			nodes = append(nodes, tn.node(d, i))
+		}
+	}
+	slices.SortFunc(nodes, func(a, b *enode.Node) int {
+		return enode.DistCmp(tn.target.id(), a.ID(), b.ID())
+	})
+	return nodes[:n]
+}
+
+var _ = (*preminedTestnet).mine // avoid linter warning about mine being dead code.
+
+// mine generates a testnet struct literal with nodes at
+// various distances to the network's target.
+func (tn *preminedTestnet) mine() {
+	// Clear existing slices first (useful when re-mining).
+	for i := range tn.dists {
+		tn.dists[i] = nil
+	}
+
+	targetSha := tn.target.id()
+	found, need := 0, 40
+	for found < need {
+		k := newkey()
+		ld := enode.LogDist(targetSha, encodePubkey(&k.PublicKey).id())
+		if len(tn.dists[ld]) < 8 {
+			tn.dists[ld] = append(tn.dists[ld], k)
+			found++
+			fmt.Printf("found ID with ld %d (%d/%d)\n", ld, found, need)
+		}
+	}
+	fmt.Printf("&preminedTestnet{\n")
+	fmt.Printf("	target: hexEncPubkey(\"%x\"),\n", tn.target[:])
+	fmt.Printf("	dists: [%d][]*ecdsa.PrivateKey{\n", len(tn.dists))
+	for ld, ns := range tn.dists {
+		if len(ns) == 0 {
+			continue
+		}
+		fmt.Printf("		%d: {\n", ld)
+		for _, key := range ns {
+			fmt.Printf("			hexEncPrivkey(\"%x\"),\n", crypto.FromECDSA(key))
+		}
+		fmt.Printf("		},\n")
+	}
+	fmt.Printf("	},\n")
+	fmt.Printf("}\n")
+}

--- a/pkg/eth/v4_udp_test.go
+++ b/pkg/eth/v4_udp_test.go
@@ -1,0 +1,665 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package eth
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	crand "crypto/rand"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"net"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p/discover/v4wire"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
+)
+
+// shared test variables
+var (
+	futureExp          = uint64(time.Now().Add(10 * time.Hour).Unix())
+	testTarget         = v4wire.Pubkey{0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1}
+	testRemote         = v4wire.Endpoint{IP: net.ParseIP("1.1.1.1").To4(), UDP: 1, TCP: 2}
+	testLocalAnnounced = v4wire.Endpoint{IP: net.ParseIP("2.2.2.2").To4(), UDP: 3, TCP: 4}
+	testLocal          = v4wire.Endpoint{IP: net.ParseIP("3.3.3.3").To4(), UDP: 5, TCP: 6}
+)
+
+type udpTest struct {
+	t                   *testing.T
+	pipe                *dgramPipe
+	table               *Table
+	db                  *enode.DB
+	udp                 *UDPv4
+	sent                [][]byte
+	localkey, remotekey *ecdsa.PrivateKey
+	remoteaddr          *net.UDPAddr
+}
+
+func newUDPTest(t *testing.T) *udpTest {
+	test := &udpTest{
+		t:          t,
+		pipe:       newpipe(),
+		localkey:   newkey(),
+		remotekey:  newkey(),
+		remoteaddr: &net.UDPAddr{IP: net.IP{10, 0, 1, 99}, Port: 30303},
+	}
+
+	test.db, _ = enode.OpenDB("")
+	ln := enode.NewLocalNode(test.db, test.localkey)
+	test.udp, _ = ListenV4(test.pipe, ln, Config{
+		PrivateKey: test.localkey,
+		Log:        Logger(t, log.LvlTrace),
+	})
+	test.table = test.udp.tab
+	// Wait for initial refresh so the table doesn't send unexpected findnode.
+	<-test.table.initDone
+	return test
+}
+
+func (test *udpTest) close() {
+	test.udp.Close()
+	test.db.Close()
+}
+
+// handles a packet as if it had been sent to the transport.
+func (test *udpTest) packetIn(wantError error, data v4wire.Packet) {
+	test.t.Helper()
+
+	test.packetInFrom(wantError, test.remotekey, test.remoteaddr, data)
+}
+
+// handles a packet as if it had been sent to the transport by the key/endpoint.
+func (test *udpTest) packetInFrom(wantError error, key *ecdsa.PrivateKey, addr *net.UDPAddr, data v4wire.Packet) {
+	test.t.Helper()
+
+	enc, _, err := v4wire.Encode(key, data)
+	if err != nil {
+		test.t.Errorf("%s encode error: %v", data.Name(), err)
+	}
+	test.sent = append(test.sent, enc)
+	if err = test.udp.handlePacket(addr, enc); err != wantError {
+		test.t.Errorf("error mismatch: got %q, want %q", err, wantError)
+	}
+}
+
+// waits for a packet to be sent by the transport.
+// validate should have type func(X, *net.UDPAddr, []byte), where X is a packet type.
+func (test *udpTest) waitPacketOut(validate interface{}) (closed bool) {
+	test.t.Helper()
+
+	dgram, err := test.pipe.receive()
+	if err == errClosed {
+		return true
+	} else if err != nil {
+		test.t.Error("packet receive error:", err)
+		return false
+	}
+	p, _, hash, err := v4wire.Decode(dgram.data)
+	if err != nil {
+		test.t.Errorf("sent packet decode error: %v", err)
+		return false
+	}
+	fn := reflect.ValueOf(validate)
+	exptype := fn.Type().In(0)
+	if !reflect.TypeOf(p).AssignableTo(exptype) {
+		test.t.Errorf("sent packet type mismatch, got: %v, want: %v", reflect.TypeOf(p), exptype)
+		return false
+	}
+	fn.Call([]reflect.Value{reflect.ValueOf(p), reflect.ValueOf(&dgram.to), reflect.ValueOf(hash)})
+	return false
+}
+
+func TestUDPv4_packetErrors(t *testing.T) {
+	test := newUDPTest(t)
+	defer test.close()
+
+	test.packetIn(errExpired, &v4wire.Ping{From: testRemote, To: testLocalAnnounced, Version: 4})
+	test.packetIn(errUnsolicitedReply, &v4wire.Pong{ReplyTok: []byte{}, Expiration: futureExp})
+	test.packetIn(errUnknownNode, &v4wire.Findnode{Expiration: futureExp})
+	test.packetIn(errUnsolicitedReply, &v4wire.Neighbors{Expiration: futureExp})
+}
+
+func TestUDPv4_pingTimeout(t *testing.T) {
+	t.Parallel()
+	test := newUDPTest(t)
+	defer test.close()
+
+	key := newkey()
+	toaddr := &net.UDPAddr{IP: net.ParseIP("1.2.3.4"), Port: 2222}
+	node := enode.NewV4(&key.PublicKey, toaddr.IP, 0, toaddr.Port)
+	if _, err := test.udp.ping(node); err != ErrTimeout {
+		t.Error("expected timeout error, got", err)
+	}
+}
+
+type testPacket byte
+
+func (req testPacket) Kind() byte   { return byte(req) }
+func (req testPacket) Name() string { return "" }
+
+func TestUDPv4_responseTimeouts(t *testing.T) {
+	t.Parallel()
+	test := newUDPTest(t)
+	defer test.close()
+
+	randomDuration := func(max time.Duration) time.Duration {
+		return time.Duration(rand.Int63n(int64(max)))
+	}
+
+	var (
+		nReqs      = 200
+		nTimeouts  = 0                       // number of requests with ptype > 128
+		nilErr     = make(chan error, nReqs) // for requests that get a reply
+		timeoutErr = make(chan error, nReqs) // for requests that time out
+	)
+	for i := 0; i < nReqs; i++ {
+		// Create a matcher for a random request in udp.loop. Requests
+		// with ptype <= 128 will not get a reply and should time out.
+		// For all other requests, a reply is scheduled to arrive
+		// within the timeout window.
+		p := &replyMatcher{
+			ptype:    byte(rand.Intn(255)),
+			callback: func(v4wire.Packet) (bool, bool) { return true, true },
+		}
+		binary.BigEndian.PutUint64(p.from[:], uint64(i))
+		if p.ptype <= 128 {
+			p.errc = timeoutErr
+			test.udp.addReplyMatcher <- p
+			nTimeouts++
+		} else {
+			p.errc = nilErr
+			test.udp.addReplyMatcher <- p
+			time.AfterFunc(randomDuration(60*time.Millisecond), func() {
+				if !test.udp.handleReply(p.from, p.ip, testPacket(p.ptype)) {
+					t.Logf("not matched: %v", p)
+				}
+			})
+		}
+		time.Sleep(randomDuration(30 * time.Millisecond))
+	}
+
+	// Check that all timeouts were delivered and that the rest got nil errors.
+	// The replies must be delivered.
+	var (
+		recvDeadline        = time.After(20 * time.Second)
+		nTimeoutsRecv, nNil = 0, 0
+	)
+	for i := 0; i < nReqs; i++ {
+		select {
+		case err := <-timeoutErr:
+			if err != ErrTimeout {
+				t.Fatalf("got non-timeout error on timeoutErr %d: %v", i, err)
+			}
+			nTimeoutsRecv++
+		case err := <-nilErr:
+			if err != nil {
+				t.Fatalf("got non-nil error on nilErr %d: %v", i, err)
+			}
+			nNil++
+		case <-recvDeadline:
+			t.Fatalf("exceeded recv deadline")
+		}
+	}
+	if nTimeoutsRecv != nTimeouts {
+		t.Errorf("wrong number of timeout errors received: got %d, want %d", nTimeoutsRecv, nTimeouts)
+	}
+	if nNil != nReqs-nTimeouts {
+		t.Errorf("wrong number of successful replies: got %d, want %d", nNil, nReqs-nTimeouts)
+	}
+}
+
+func TestUDPv4_findnodeTimeout(t *testing.T) {
+	t.Parallel()
+	test := newUDPTest(t)
+	defer test.close()
+
+	toaddr := &net.UDPAddr{IP: net.ParseIP("1.2.3.4"), Port: 2222}
+	toid := enode.ID{1, 2, 3, 4}
+	target := v4wire.Pubkey{4, 5, 6, 7}
+	result, err := test.udp.findnode(toid, toaddr, target)
+	if err != ErrTimeout {
+		t.Error("expected timeout error, got", err)
+	}
+	if len(result) > 0 {
+		t.Error("expected empty result, got", result)
+	}
+}
+
+func TestUDPv4_findnode(t *testing.T) {
+	test := newUDPTest(t)
+	defer test.close()
+
+	// put a few nodes into the table. their exact
+	// distribution shouldn't matter much, although we need to
+	// take care not to overflow any bucket.
+	nodes := &nodesByDistance{target: testTarget.ID()}
+	live := make(map[enode.ID]bool)
+	numCandidates := 2 * bucketSize
+	for i := 0; i < numCandidates; i++ {
+		key := newkey()
+		ip := net.IP{10, 13, 0, byte(i)}
+		n := wrapNode(enode.NewV4(&key.PublicKey, ip, 0, 2000))
+		// Ensure half of table content isn't verified live yet.
+		if i > numCandidates/2 {
+			n.livenessChecks = 1
+			live[n.ID()] = true
+		}
+		nodes.push(n, numCandidates)
+	}
+	fillTable(test.table, nodes.entries)
+
+	// ensure there's a bond with the test node,
+	// findnode won't be accepted otherwise.
+	remoteID := v4wire.EncodePubkey(&test.remotekey.PublicKey).ID()
+	test.table.db.UpdateLastPongReceived(remoteID, test.remoteaddr.IP, time.Now())
+
+	// check that closest neighbors are returned.
+	expected := test.table.findnodeByID(testTarget.ID(), bucketSize, true)
+	test.packetIn(nil, &v4wire.Findnode{Target: testTarget, Expiration: futureExp})
+	waitNeighbors := func(want []*node) {
+		test.waitPacketOut(func(p *v4wire.Neighbors, to *net.UDPAddr, hash []byte) {
+			if len(p.Nodes) != len(want) {
+				t.Errorf("wrong number of results: got %d, want %d", len(p.Nodes), bucketSize)
+				return
+			}
+			for i, n := range p.Nodes {
+				if n.ID.ID() != want[i].ID() {
+					t.Errorf("result mismatch at %d:\n  got:  %v\n  want: %v", i, n, expected.entries[i])
+				}
+				if !live[n.ID.ID()] {
+					t.Errorf("result includes dead node %v", n.ID.ID())
+				}
+			}
+		})
+	}
+	// Receive replies.
+	want := expected.entries
+	if len(want) > v4wire.MaxNeighbors {
+		waitNeighbors(want[:v4wire.MaxNeighbors])
+		want = want[v4wire.MaxNeighbors:]
+	}
+	waitNeighbors(want)
+}
+
+func TestUDPv4_findnodeMultiReply(t *testing.T) {
+	test := newUDPTest(t)
+	defer test.close()
+
+	rid := enode.PubkeyToIDV4(&test.remotekey.PublicKey)
+	test.table.db.UpdateLastPingReceived(rid, test.remoteaddr.IP, time.Now())
+
+	// queue a pending findnode request
+	resultc, errc := make(chan []*node, 1), make(chan error, 1)
+	go func() {
+		rid := encodePubkey(&test.remotekey.PublicKey).id()
+		ns, err := test.udp.findnode(rid, test.remoteaddr, testTarget)
+		if err != nil && len(ns) == 0 {
+			errc <- err
+		} else {
+			resultc <- ns
+		}
+	}()
+
+	// wait for the findnode to be sent.
+	// after it is sent, the transport is waiting for a reply
+	test.waitPacketOut(func(p *v4wire.Findnode, to *net.UDPAddr, hash []byte) {
+		if p.Target != testTarget {
+			t.Errorf("wrong target: got %v, want %v", p.Target, testTarget)
+		}
+	})
+
+	// send the reply as two packets.
+	list := []*node{
+		wrapNode(enode.MustParse("enode://ba85011c70bcc5c04d8607d3a0ed29aa6179c092cbdda10d5d32684fb33ed01bd94f588ca8f91ac48318087dcb02eaf36773a7a453f0eedd6742af668097b29c@10.0.1.16:30303?discport=30304")),
+		wrapNode(enode.MustParse("enode://81fa361d25f157cd421c60dcc28d8dac5ef6a89476633339c5df30287474520caca09627da18543d9079b5b288698b542d56167aa5c09111e55acdbbdf2ef799@10.0.1.16:30303")),
+		wrapNode(enode.MustParse("enode://9bffefd833d53fac8e652415f4973bee289e8b1a5c6c4cbe70abf817ce8a64cee11b823b66a987f51aaa9fba0d6a91b3e6bf0d5a5d1042de8e9eeea057b217f8@10.0.1.36:30301?discport=17")),
+		wrapNode(enode.MustParse("enode://1b5b4aa662d7cb44a7221bfba67302590b643028197a7d5214790f3bac7aaa4a3241be9e83c09cf1f6c69d007c634faae3dc1b1221793e8446c0b3a09de65960@10.0.1.16:30303")),
+	}
+	rpclist := make([]v4wire.Node, len(list))
+	for i := range list {
+		rpclist[i] = nodeToRPC(list[i])
+	}
+	test.packetIn(nil, &v4wire.Neighbors{Expiration: futureExp, Nodes: rpclist[:2]})
+	test.packetIn(nil, &v4wire.Neighbors{Expiration: futureExp, Nodes: rpclist[2:]})
+
+	// check that the sent neighbors are all returned by findnode
+	select {
+	case result := <-resultc:
+		want := append(list[:2], list[3:]...)
+		if !reflect.DeepEqual(result, want) {
+			t.Errorf("neighbors mismatch:\n  got:  %v\n  want: %v", result, want)
+		}
+	case err := <-errc:
+		t.Errorf("findnode error: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Error("findnode did not return within 5 seconds")
+	}
+}
+
+// This test checks that reply matching of pong verifies the ping hash.
+func TestUDPv4_pingMatch(t *testing.T) {
+	test := newUDPTest(t)
+	defer test.close()
+
+	randToken := make([]byte, 32)
+	crand.Read(randToken)
+
+	test.packetIn(nil, &v4wire.Ping{From: testRemote, To: testLocalAnnounced, Version: 4, Expiration: futureExp})
+	test.waitPacketOut(func(*v4wire.Pong, *net.UDPAddr, []byte) {})
+	test.waitPacketOut(func(*v4wire.Ping, *net.UDPAddr, []byte) {})
+	test.packetIn(errUnsolicitedReply, &v4wire.Pong{ReplyTok: randToken, To: testLocalAnnounced, Expiration: futureExp})
+}
+
+// This test checks that reply matching of pong verifies the sender IP address.
+func TestUDPv4_pingMatchIP(t *testing.T) {
+	test := newUDPTest(t)
+	defer test.close()
+
+	test.packetIn(nil, &v4wire.Ping{From: testRemote, To: testLocalAnnounced, Version: 4, Expiration: futureExp})
+	test.waitPacketOut(func(*v4wire.Pong, *net.UDPAddr, []byte) {})
+
+	test.waitPacketOut(func(p *v4wire.Ping, to *net.UDPAddr, hash []byte) {
+		wrongAddr := &net.UDPAddr{IP: net.IP{33, 44, 1, 2}, Port: 30000}
+		test.packetInFrom(errUnsolicitedReply, test.remotekey, wrongAddr, &v4wire.Pong{
+			ReplyTok:   hash,
+			To:         testLocalAnnounced,
+			Expiration: futureExp,
+		})
+	})
+}
+
+func TestUDPv4_successfulPing(t *testing.T) {
+	test := newUDPTest(t)
+	added := make(chan *node, 1)
+	test.table.nodeAddedHook = func(b *bucket, n *node) { added <- n }
+	defer test.close()
+
+	// The remote side sends a ping packet to initiate the exchange.
+	go test.packetIn(nil, &v4wire.Ping{From: testRemote, To: testLocalAnnounced, Version: 4, Expiration: futureExp})
+
+	// The ping is replied to.
+	test.waitPacketOut(func(p *v4wire.Pong, to *net.UDPAddr, hash []byte) {
+		pinghash := test.sent[0][:32]
+		if !bytes.Equal(p.ReplyTok, pinghash) {
+			t.Errorf("got pong.ReplyTok %x, want %x", p.ReplyTok, pinghash)
+		}
+		wantTo := v4wire.Endpoint{
+			// The mirrored UDP address is the UDP packet sender
+			IP: test.remoteaddr.IP, UDP: uint16(test.remoteaddr.Port),
+			// The mirrored TCP port is the one from the ping packet
+			TCP: testRemote.TCP,
+		}
+		if !reflect.DeepEqual(p.To, wantTo) {
+			t.Errorf("got pong.To %v, want %v", p.To, wantTo)
+		}
+	})
+
+	// Remote is unknown, the table pings back.
+	test.waitPacketOut(func(p *v4wire.Ping, to *net.UDPAddr, hash []byte) {
+		if !reflect.DeepEqual(p.From, test.udp.ourEndpoint()) {
+			t.Errorf("got ping.From %#v, want %#v", p.From, test.udp.ourEndpoint())
+		}
+		wantTo := v4wire.Endpoint{
+			// The mirrored UDP address is the UDP packet sender.
+			IP:  test.remoteaddr.IP,
+			UDP: uint16(test.remoteaddr.Port),
+			TCP: 0,
+		}
+		if !reflect.DeepEqual(p.To, wantTo) {
+			t.Errorf("got ping.To %v, want %v", p.To, wantTo)
+		}
+		test.packetIn(nil, &v4wire.Pong{ReplyTok: hash, Expiration: futureExp})
+	})
+
+	// The node should be added to the table shortly after getting the
+	// pong packet.
+	select {
+	case n := <-added:
+		rid := encodePubkey(&test.remotekey.PublicKey).id()
+		if n.ID() != rid {
+			t.Errorf("node has wrong ID: got %v, want %v", n.ID(), rid)
+		}
+		if !n.IP().Equal(test.remoteaddr.IP) {
+			t.Errorf("node has wrong IP: got %v, want: %v", n.IP(), test.remoteaddr.IP)
+		}
+		if n.UDP() != test.remoteaddr.Port {
+			t.Errorf("node has wrong UDP port: got %v, want: %v", n.UDP(), test.remoteaddr.Port)
+		}
+		if n.TCP() != int(testRemote.TCP) {
+			t.Errorf("node has wrong TCP port: got %v, want: %v", n.TCP(), testRemote.TCP)
+		}
+	case <-time.After(2 * time.Second):
+		t.Errorf("node was not added within 2 seconds")
+	}
+}
+
+// This test checks that EIP-868 requests work.
+func TestUDPv4_EIP868(t *testing.T) {
+	test := newUDPTest(t)
+	defer test.close()
+
+	test.udp.localNode.Set(enr.WithEntry("foo", "bar"))
+	wantNode := test.udp.localNode.Node()
+
+	// ENR requests aren't allowed before endpoint proof.
+	test.packetIn(errUnknownNode, &v4wire.ENRRequest{Expiration: futureExp})
+
+	// Perform endpoint proof and check for sequence number in packet tail.
+	test.packetIn(nil, &v4wire.Ping{Expiration: futureExp})
+	test.waitPacketOut(func(p *v4wire.Pong, addr *net.UDPAddr, hash []byte) {
+		if p.ENRSeq != wantNode.Seq() {
+			t.Errorf("wrong sequence number in pong: %d, want %d", p.ENRSeq, wantNode.Seq())
+		}
+	})
+	test.waitPacketOut(func(p *v4wire.Ping, addr *net.UDPAddr, hash []byte) {
+		if p.ENRSeq != wantNode.Seq() {
+			t.Errorf("wrong sequence number in ping: %d, want %d", p.ENRSeq, wantNode.Seq())
+		}
+		test.packetIn(nil, &v4wire.Pong{Expiration: futureExp, ReplyTok: hash})
+	})
+
+	// Request should work now.
+	test.packetIn(nil, &v4wire.ENRRequest{Expiration: futureExp})
+	test.waitPacketOut(func(p *v4wire.ENRResponse, addr *net.UDPAddr, hash []byte) {
+		n, err := enode.New(enode.ValidSchemes, &p.Record)
+		if err != nil {
+			t.Fatalf("invalid record: %v", err)
+		}
+		if !reflect.DeepEqual(n, wantNode) {
+			t.Fatalf("wrong node in ENRResponse: %v", n)
+		}
+	})
+}
+
+// This test verifies that a small network of nodes can boot up into a healthy state.
+func TestUDPv4_smallNetConvergence(t *testing.T) {
+	t.Parallel()
+
+	// Start the network.
+	nodes := make([]*UDPv4, 4)
+	for i := range nodes {
+		var cfg Config
+		if i > 0 {
+			bn := nodes[0].Self()
+			cfg.Bootnodes = []*enode.Node{bn}
+		}
+		nodes[i] = startLocalhostV4(t, cfg)
+		defer nodes[i].Close()
+	}
+
+	// Run through the iterator on all nodes until
+	// they have all found each other.
+	status := make(chan error, len(nodes))
+	for i := range nodes {
+		node := nodes[i]
+		go func() {
+			found := make(map[enode.ID]bool, len(nodes))
+			it := node.RandomNodes()
+			for it.Next() {
+				found[it.Node().ID()] = true
+				if len(found) == len(nodes) {
+					status <- nil
+					return
+				}
+			}
+			status <- fmt.Errorf("node %s didn't find all nodes", node.Self().ID().TerminalString())
+		}()
+	}
+
+	// Wait for all status reports.
+	timeout := time.NewTimer(30 * time.Second)
+	defer timeout.Stop()
+	for received := 0; received < len(nodes); {
+		select {
+		case <-timeout.C:
+			for _, node := range nodes {
+				node.Close()
+			}
+		case err := <-status:
+			received++
+			if err != nil {
+				t.Error("ERROR:", err)
+				return
+			}
+		}
+	}
+}
+
+func startLocalhostV4(t *testing.T, cfg Config) *UDPv4 {
+	t.Helper()
+
+	cfg.PrivateKey = newkey()
+	db, _ := enode.OpenDB("")
+	ln := enode.NewLocalNode(db, cfg.PrivateKey)
+
+	// Prefix logs with node ID.
+	lprefix := fmt.Sprintf("(%s)", ln.ID().TerminalString())
+	lfmt := log.TerminalFormat(false)
+	cfg.Log = Logger(t, log.LvlTrace)
+	cfg.Log.SetHandler(log.FuncHandler(func(r *log.Record) error {
+		t.Logf("%s %s", lprefix, lfmt.Format(r))
+		return nil
+	}))
+
+	// Listen.
+	socket, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IP{127, 0, 0, 1}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	realaddr := socket.LocalAddr().(*net.UDPAddr)
+	ln.SetStaticIP(realaddr.IP)
+	ln.SetFallbackUDP(realaddr.Port)
+	udp, err := ListenV4(socket, ln, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return udp
+}
+
+// dgramPipe is a fake UDP socket. It queues all sent datagrams.
+type dgramPipe struct {
+	mu      *sync.Mutex
+	cond    *sync.Cond
+	closing chan struct{}
+	closed  bool
+	queue   []dgram
+}
+
+type dgram struct {
+	to   net.UDPAddr
+	data []byte
+}
+
+func newpipe() *dgramPipe {
+	mu := new(sync.Mutex)
+	return &dgramPipe{
+		closing: make(chan struct{}),
+		cond:    &sync.Cond{L: mu},
+		mu:      mu,
+	}
+}
+
+// WriteToUDP queues a datagram.
+func (c *dgramPipe) WriteToUDP(b []byte, to *net.UDPAddr) (n int, err error) {
+	msg := make([]byte, len(b))
+	copy(msg, b)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return 0, errors.New("closed")
+	}
+	c.queue = append(c.queue, dgram{*to, b})
+	c.cond.Signal()
+	return len(b), nil
+}
+
+// ReadFromUDP just hangs until the pipe is closed.
+func (c *dgramPipe) ReadFromUDP(b []byte) (n int, addr *net.UDPAddr, err error) {
+	<-c.closing
+	return 0, nil, io.EOF
+}
+
+func (c *dgramPipe) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.closed {
+		close(c.closing)
+		c.closed = true
+	}
+	c.cond.Broadcast()
+	return nil
+}
+
+func (c *dgramPipe) LocalAddr() net.Addr {
+	return &net.UDPAddr{IP: testLocal.IP, Port: int(testLocal.UDP)}
+}
+
+func (c *dgramPipe) receive() (dgram, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var timedOut bool
+	timer := time.AfterFunc(3*time.Second, func() {
+		c.mu.Lock()
+		timedOut = true
+		c.mu.Unlock()
+		c.cond.Broadcast()
+	})
+	defer timer.Stop()
+
+	for len(c.queue) == 0 && !c.closed && !timedOut {
+		c.cond.Wait()
+	}
+	if c.closed {
+		return dgram{}, errClosed
+	}
+	if timedOut {
+		return dgram{}, ErrTimeout
+	}
+	p := c.queue[0]
+	copy(c.queue, c.queue[1:])
+	c.queue = c.queue[:len(c.queue)-1]
+	return p, nil
+}

--- a/pkg/eth/v5_udp_test.go
+++ b/pkg/eth/v5_udp_test.go
@@ -1,0 +1,863 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package eth
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"net"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p/discover/v5wire"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+)
+
+// Real sockets, real crypto: this test checks end-to-end connectivity for UDPv5.
+func TestUDPv5_lookupE2E(t *testing.T) {
+	t.Parallel()
+
+	const N = 5
+	var nodes []*UDPv5
+	for i := 0; i < N; i++ {
+		var cfg Config
+		if len(nodes) > 0 {
+			bn := nodes[0].Self()
+			cfg.Bootnodes = []*enode.Node{bn}
+		}
+		node := startLocalhostV5(t, cfg)
+		nodes = append(nodes, node)
+		defer node.Close()
+	}
+	last := nodes[N-1]
+	target := nodes[rand.Intn(N-2)].Self()
+
+	// It is expected that all nodes can be found.
+	expectedResult := make([]*enode.Node, len(nodes))
+	for i := range nodes {
+		expectedResult[i] = nodes[i].Self()
+	}
+	slices.SortFunc(expectedResult, func(a, b *enode.Node) int {
+		return enode.DistCmp(target.ID(), a.ID(), b.ID())
+	})
+
+	// Do the lookup.
+	results := last.Lookup(target.ID())
+	if err := checkNodesEqual(results, expectedResult); err != nil {
+		t.Fatalf("lookup returned wrong results: %v", err)
+	}
+}
+
+func startLocalhostV5(t *testing.T, cfg Config) *UDPv5 {
+	cfg.PrivateKey = newkey()
+	db, _ := enode.OpenDB("")
+	ln := enode.NewLocalNode(db, cfg.PrivateKey)
+
+	// Prefix logs with node ID.
+	lprefix := fmt.Sprintf("(%s)", ln.ID().TerminalString())
+	lfmt := log.TerminalFormat(false)
+	cfg.Log = Logger(t, log.LvlTrace)
+	cfg.Log.SetHandler(log.FuncHandler(func(r *log.Record) error {
+		t.Logf("%s %s", lprefix, lfmt.Format(r))
+		return nil
+	}))
+
+	// Listen.
+	socket, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IP{127, 0, 0, 1}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	realaddr := socket.LocalAddr().(*net.UDPAddr)
+	ln.SetStaticIP(realaddr.IP)
+	ln.Set(enr.UDP(realaddr.Port))
+	udp, err := ListenV5(socket, ln, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return udp
+}
+
+// This test checks that incoming PING calls are handled correctly.
+func TestUDPv5_pingHandling(t *testing.T) {
+	t.Parallel()
+	test := newUDPV5Test(t)
+	defer test.close()
+
+	test.packetIn(&v5wire.Ping{ReqID: []byte("foo")})
+	test.waitPacketOut(func(p *v5wire.Pong, addr *net.UDPAddr, _ v5wire.Nonce) {
+		if !bytes.Equal(p.ReqID, []byte("foo")) {
+			t.Error("wrong request ID in response:", p.ReqID)
+		}
+		if p.ENRSeq != test.table.self().Seq() {
+			t.Error("wrong ENR sequence number in response:", p.ENRSeq)
+		}
+	})
+}
+
+// This test checks that incoming 'unknown' packets trigger the handshake.
+func TestUDPv5_unknownPacket(t *testing.T) {
+	t.Parallel()
+	test := newUDPV5Test(t)
+	defer test.close()
+
+	nonce := v5wire.Nonce{1, 2, 3}
+	check := func(p *v5wire.Whoareyou, wantSeq uint64) {
+		t.Helper()
+		if p.Nonce != nonce {
+			t.Error("wrong nonce in WHOAREYOU:", p.Nonce, nonce)
+		}
+		if p.IDNonce == ([16]byte{}) {
+			t.Error("all zero ID nonce")
+		}
+		if p.RecordSeq != wantSeq {
+			t.Errorf("wrong record seq %d in WHOAREYOU, want %d", p.RecordSeq, wantSeq)
+		}
+	}
+
+	// Unknown packet from unknown node.
+	test.packetIn(&v5wire.Unknown{Nonce: nonce})
+	test.waitPacketOut(func(p *v5wire.Whoareyou, addr *net.UDPAddr, _ v5wire.Nonce) {
+		check(p, 0)
+	})
+
+	// Make node known.
+	n := test.getNode(test.remotekey, test.remoteaddr).Node()
+	test.table.addSeenNode(wrapNode(n))
+
+	test.packetIn(&v5wire.Unknown{Nonce: nonce})
+	test.waitPacketOut(func(p *v5wire.Whoareyou, addr *net.UDPAddr, _ v5wire.Nonce) {
+		check(p, n.Seq())
+	})
+}
+
+// This test checks that incoming FINDNODE calls are handled correctly.
+func TestUDPv5_findnodeHandling(t *testing.T) {
+	t.Parallel()
+	test := newUDPV5Test(t)
+	defer test.close()
+
+	// Create test nodes and insert them into the table.
+	nodes253 := nodesAtDistance(test.table.self().ID(), 253, 16)
+	nodes249 := nodesAtDistance(test.table.self().ID(), 249, 4)
+	nodes248 := nodesAtDistance(test.table.self().ID(), 248, 10)
+	fillTable(test.table, wrapNodes(nodes253))
+	fillTable(test.table, wrapNodes(nodes249))
+	fillTable(test.table, wrapNodes(nodes248))
+
+	// Requesting with distance zero should return the node's own record.
+	test.packetIn(&v5wire.Findnode{ReqID: []byte{0}, Distances: []uint{0}})
+	test.expectNodes([]byte{0}, 1, []*enode.Node{test.udp.Self()})
+
+	// Requesting with distance > 256 shouldn't crash.
+	test.packetIn(&v5wire.Findnode{ReqID: []byte{1}, Distances: []uint{4234098}})
+	test.expectNodes([]byte{1}, 1, nil)
+
+	// Requesting with empty distance list shouldn't crash either.
+	test.packetIn(&v5wire.Findnode{ReqID: []byte{2}, Distances: []uint{}})
+	test.expectNodes([]byte{2}, 1, nil)
+
+	// This request gets no nodes because the corresponding bucket is empty.
+	test.packetIn(&v5wire.Findnode{ReqID: []byte{3}, Distances: []uint{254}})
+	test.expectNodes([]byte{3}, 1, nil)
+
+	// This request gets all the distance-253 nodes.
+	test.packetIn(&v5wire.Findnode{ReqID: []byte{4}, Distances: []uint{253}})
+	test.expectNodes([]byte{4}, 2, nodes253)
+
+	// This request gets all the distance-249 nodes and some more at 248 because
+	// the bucket at 249 is not full.
+	test.packetIn(&v5wire.Findnode{ReqID: []byte{5}, Distances: []uint{249, 248}})
+	var nodes []*enode.Node
+	nodes = append(nodes, nodes249...)
+	nodes = append(nodes, nodes248[:10]...)
+	test.expectNodes([]byte{5}, 1, nodes)
+}
+
+func (test *udpV5Test) expectNodes(wantReqID []byte, wantTotal uint8, wantNodes []*enode.Node) {
+	nodeSet := make(map[enode.ID]*enr.Record, len(wantNodes))
+	for _, n := range wantNodes {
+		nodeSet[n.ID()] = n.Record()
+	}
+
+	for {
+		test.waitPacketOut(func(p *v5wire.Nodes, addr *net.UDPAddr, _ v5wire.Nonce) {
+			if !bytes.Equal(p.ReqID, wantReqID) {
+				test.t.Fatalf("wrong request ID %v in response, want %v", p.ReqID, wantReqID)
+			}
+			if p.RespCount != wantTotal {
+				test.t.Fatalf("wrong total response count %d, want %d", p.RespCount, wantTotal)
+			}
+			for _, record := range p.Nodes {
+				n, _ := enode.New(enode.ValidSchemesForTesting, record)
+				want := nodeSet[n.ID()]
+				if want == nil {
+					test.t.Fatalf("unexpected node in response: %v", n)
+				}
+				if !reflect.DeepEqual(record, want) {
+					test.t.Fatalf("wrong record in response: %v", n)
+				}
+				delete(nodeSet, n.ID())
+			}
+		})
+		if len(nodeSet) == 0 {
+			return
+		}
+	}
+}
+
+// This test checks that outgoing PING calls work.
+func TestUDPv5_pingCall(t *testing.T) {
+	t.Parallel()
+	test := newUDPV5Test(t)
+	defer test.close()
+
+	remote := test.getNode(test.remotekey, test.remoteaddr).Node()
+	done := make(chan error, 1)
+
+	// This ping times out.
+	go func() {
+		_, err := test.udp.ping(remote)
+		done <- err
+	}()
+	test.waitPacketOut(func(p *v5wire.Ping, addr *net.UDPAddr, _ v5wire.Nonce) {})
+	if err := <-done; err != ErrTimeout {
+		t.Fatalf("want ErrTimeout, got %q", err)
+	}
+
+	// This ping works.
+	go func() {
+		_, err := test.udp.ping(remote)
+		done <- err
+	}()
+	test.waitPacketOut(func(p *v5wire.Ping, addr *net.UDPAddr, _ v5wire.Nonce) {
+		test.packetInFrom(test.remotekey, test.remoteaddr, &v5wire.Pong{ReqID: p.ReqID})
+	})
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+
+	// This ping gets a reply from the wrong endpoint.
+	go func() {
+		_, err := test.udp.ping(remote)
+		done <- err
+	}()
+	test.waitPacketOut(func(p *v5wire.Ping, addr *net.UDPAddr, _ v5wire.Nonce) {
+		wrongAddr := &net.UDPAddr{IP: net.IP{33, 44, 55, 22}, Port: 10101}
+		test.packetInFrom(test.remotekey, wrongAddr, &v5wire.Pong{ReqID: p.ReqID})
+	})
+	if err := <-done; err != ErrTimeout {
+		t.Fatalf("want errTimeout for reply from wrong IP, got %q", err)
+	}
+}
+
+// This test checks that outgoing FINDNODE calls work and multiple NODES
+// replies are aggregated.
+func TestUDPv5_findnodeCall(t *testing.T) {
+	t.Parallel()
+	test := newUDPV5Test(t)
+	defer test.close()
+
+	// Launch the request:
+	var (
+		distances = []uint{230}
+		remote    = test.getNode(test.remotekey, test.remoteaddr).Node()
+		nodes     = nodesAtDistance(remote.ID(), int(distances[0]), 8)
+		done      = make(chan error, 1)
+		response  []*enode.Node
+	)
+	go func() {
+		var err error
+		response, err = test.udp.FindNode(remote, distances)
+		done <- err
+	}()
+
+	// Serve the responses:
+	test.waitPacketOut(func(p *v5wire.Findnode, addr *net.UDPAddr, _ v5wire.Nonce) {
+		if !reflect.DeepEqual(p.Distances, distances) {
+			t.Fatalf("wrong distances in request: %v", p.Distances)
+		}
+		test.packetIn(&v5wire.Nodes{
+			ReqID:     p.ReqID,
+			RespCount: 2,
+			Nodes:     nodesToRecords(nodes[:4]),
+		})
+		test.packetIn(&v5wire.Nodes{
+			ReqID:     p.ReqID,
+			RespCount: 2,
+			Nodes:     nodesToRecords(nodes[4:]),
+		})
+	})
+
+	// Check results:
+	if err := <-done; err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(response, nodes) {
+		t.Fatalf("wrong nodes in response")
+	}
+
+	// TODO: check invalid IPs
+	// TODO: check invalid/unsigned record
+}
+
+// This test checks that pending calls are re-sent when a handshake happens.
+func TestUDPv5_callResend(t *testing.T) {
+	t.Parallel()
+	test := newUDPV5Test(t)
+	defer test.close()
+
+	remote := test.getNode(test.remotekey, test.remoteaddr).Node()
+	done := make(chan error, 2)
+	go func() {
+		_, err := test.udp.ping(remote)
+		done <- err
+	}()
+	go func() {
+		_, err := test.udp.ping(remote)
+		done <- err
+	}()
+
+	// Ping answered by WHOAREYOU.
+	test.waitPacketOut(func(p *v5wire.Ping, addr *net.UDPAddr, nonce v5wire.Nonce) {
+		test.packetIn(&v5wire.Whoareyou{Nonce: nonce})
+	})
+	// Ping should be re-sent.
+	test.waitPacketOut(func(p *v5wire.Ping, addr *net.UDPAddr, _ v5wire.Nonce) {
+		test.packetIn(&v5wire.Pong{ReqID: p.ReqID})
+	})
+	// Answer the other ping.
+	test.waitPacketOut(func(p *v5wire.Ping, addr *net.UDPAddr, _ v5wire.Nonce) {
+		test.packetIn(&v5wire.Pong{ReqID: p.ReqID})
+	})
+	if err := <-done; err != nil {
+		t.Fatalf("unexpected ping error: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("unexpected ping error: %v", err)
+	}
+}
+
+// This test ensures we don't allow multiple rounds of WHOAREYOU for a single call.
+func TestUDPv5_multipleHandshakeRounds(t *testing.T) {
+	t.Parallel()
+	test := newUDPV5Test(t)
+	defer test.close()
+
+	remote := test.getNode(test.remotekey, test.remoteaddr).Node()
+	done := make(chan error, 1)
+	go func() {
+		_, err := test.udp.ping(remote)
+		done <- err
+	}()
+
+	// Ping answered by WHOAREYOU.
+	test.waitPacketOut(func(p *v5wire.Ping, addr *net.UDPAddr, nonce v5wire.Nonce) {
+		test.packetIn(&v5wire.Whoareyou{Nonce: nonce})
+	})
+	// Ping answered by WHOAREYOU again.
+	test.waitPacketOut(func(p *v5wire.Ping, addr *net.UDPAddr, nonce v5wire.Nonce) {
+		test.packetIn(&v5wire.Whoareyou{Nonce: nonce})
+	})
+	if err := <-done; err != ErrTimeout {
+		t.Fatalf("unexpected ping error: %q", err)
+	}
+}
+
+// This test checks that calls with n replies may take up to n * respTimeout.
+func TestUDPv5_callTimeoutReset(t *testing.T) {
+	t.Parallel()
+	test := newUDPV5Test(t)
+	defer test.close()
+
+	// Launch the request:
+	var (
+		distance = uint(230)
+		remote   = test.getNode(test.remotekey, test.remoteaddr).Node()
+		nodes    = nodesAtDistance(remote.ID(), int(distance), 8)
+		done     = make(chan error, 1)
+	)
+	go func() {
+		_, err := test.udp.FindNode(remote, []uint{distance})
+		done <- err
+	}()
+
+	// Serve two responses, slowly.
+	test.waitPacketOut(func(p *v5wire.Findnode, addr *net.UDPAddr, _ v5wire.Nonce) {
+		time.Sleep(respTimeout - 50*time.Millisecond)
+		test.packetIn(&v5wire.Nodes{
+			ReqID:     p.ReqID,
+			RespCount: 2,
+			Nodes:     nodesToRecords(nodes[:4]),
+		})
+
+		time.Sleep(respTimeout - 50*time.Millisecond)
+		test.packetIn(&v5wire.Nodes{
+			ReqID:     p.ReqID,
+			RespCount: 2,
+			Nodes:     nodesToRecords(nodes[4:]),
+		})
+	})
+	if err := <-done; err != nil {
+		t.Fatalf("unexpected error: %q", err)
+	}
+}
+
+// This test checks that TALKREQ calls the registered handler function.
+func TestUDPv5_talkHandling(t *testing.T) {
+	t.Parallel()
+	test := newUDPV5Test(t)
+	defer test.close()
+
+	var recvMessage []byte
+	test.udp.RegisterTalkHandler("test", func(id enode.ID, addr *net.UDPAddr, message []byte) []byte {
+		recvMessage = message
+		return []byte("test response")
+	})
+
+	// Successful case:
+	test.packetIn(&v5wire.TalkRequest{
+		ReqID:    []byte("foo"),
+		Protocol: "test",
+		Message:  []byte("test request"),
+	})
+	test.waitPacketOut(func(p *v5wire.TalkResponse, addr *net.UDPAddr, _ v5wire.Nonce) {
+		if !bytes.Equal(p.ReqID, []byte("foo")) {
+			t.Error("wrong request ID in response:", p.ReqID)
+		}
+		if string(p.Message) != "test response" {
+			t.Errorf("wrong talk response message: %q", p.Message)
+		}
+		if string(recvMessage) != "test request" {
+			t.Errorf("wrong message received in handler: %q", recvMessage)
+		}
+	})
+
+	// Check that empty response is returned for unregistered protocols.
+	recvMessage = nil
+	test.packetIn(&v5wire.TalkRequest{
+		ReqID:    []byte("2"),
+		Protocol: "wrong",
+		Message:  []byte("test request"),
+	})
+	test.waitPacketOut(func(p *v5wire.TalkResponse, addr *net.UDPAddr, _ v5wire.Nonce) {
+		if !bytes.Equal(p.ReqID, []byte("2")) {
+			t.Error("wrong request ID in response:", p.ReqID)
+		}
+		if string(p.Message) != "" {
+			t.Errorf("wrong talk response message: %q", p.Message)
+		}
+		if recvMessage != nil {
+			t.Errorf("handler was called for wrong protocol: %q", recvMessage)
+		}
+	})
+}
+
+// This test checks that outgoing TALKREQ calls work.
+func TestUDPv5_talkRequest(t *testing.T) {
+	t.Parallel()
+	test := newUDPV5Test(t)
+	defer test.close()
+
+	remote := test.getNode(test.remotekey, test.remoteaddr).Node()
+	done := make(chan error, 1)
+
+	// This request times out.
+	go func() {
+		_, err := test.udp.TalkRequest(remote, "test", []byte("test request"))
+		done <- err
+	}()
+	test.waitPacketOut(func(p *v5wire.TalkRequest, addr *net.UDPAddr, _ v5wire.Nonce) {})
+	if err := <-done; err != ErrTimeout {
+		t.Fatalf("want errTimeout, got %q", err)
+	}
+
+	// This request works.
+	go func() {
+		_, err := test.udp.TalkRequest(remote, "test", []byte("test request"))
+		done <- err
+	}()
+	test.waitPacketOut(func(p *v5wire.TalkRequest, addr *net.UDPAddr, _ v5wire.Nonce) {
+		if p.Protocol != "test" {
+			t.Errorf("wrong protocol ID in talk request: %q", p.Protocol)
+		}
+		if string(p.Message) != "test request" {
+			t.Errorf("wrong message talk request: %q", p.Message)
+		}
+		test.packetInFrom(test.remotekey, test.remoteaddr, &v5wire.TalkResponse{
+			ReqID:   p.ReqID,
+			Message: []byte("test response"),
+		})
+	})
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+
+	// Also check requesting without ENR.
+	go func() {
+		_, err := test.udp.TalkRequestToID(remote.ID(), test.remoteaddr, "test", []byte("test request 2"))
+		done <- err
+	}()
+	test.waitPacketOut(func(p *v5wire.TalkRequest, addr *net.UDPAddr, _ v5wire.Nonce) {
+		if p.Protocol != "test" {
+			t.Errorf("wrong protocol ID in talk request: %q", p.Protocol)
+		}
+		if string(p.Message) != "test request 2" {
+			t.Errorf("wrong message talk request: %q", p.Message)
+		}
+		test.packetInFrom(test.remotekey, test.remoteaddr, &v5wire.TalkResponse{
+			ReqID:   p.ReqID,
+			Message: []byte("test response 2"),
+		})
+	})
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+// This test checks that lookupDistances works.
+func TestUDPv5_lookupDistances(t *testing.T) {
+	test := newUDPV5Test(t)
+	lnID := test.table.self().ID()
+
+	t.Run("target distance of 1", func(t *testing.T) {
+		node := nodeAtDistance(lnID, 1, intIP(0))
+		dists := lookupDistances(lnID, node.ID())
+		require.Equal(t, []uint{1, 2, 3}, dists)
+	})
+
+	t.Run("target distance of 2", func(t *testing.T) {
+		node := nodeAtDistance(lnID, 2, intIP(0))
+		dists := lookupDistances(lnID, node.ID())
+		require.Equal(t, []uint{2, 3, 1}, dists)
+	})
+
+	t.Run("target distance of 128", func(t *testing.T) {
+		node := nodeAtDistance(lnID, 128, intIP(0))
+		dists := lookupDistances(lnID, node.ID())
+		require.Equal(t, []uint{128, 129, 127}, dists)
+	})
+
+	t.Run("target distance of 255", func(t *testing.T) {
+		node := nodeAtDistance(lnID, 255, intIP(0))
+		dists := lookupDistances(lnID, node.ID())
+		require.Equal(t, []uint{255, 256, 254}, dists)
+	})
+
+	t.Run("target distance of 256", func(t *testing.T) {
+		node := nodeAtDistance(lnID, 256, intIP(0))
+		dists := lookupDistances(lnID, node.ID())
+		require.Equal(t, []uint{256, 255, 254}, dists)
+	})
+}
+
+// This test checks that lookup works.
+func TestUDPv5_lookup(t *testing.T) {
+	t.Parallel()
+	test := newUDPV5Test(t)
+
+	// Lookup on empty table returns no nodes.
+	if results := test.udp.Lookup(lookupTestnet.target.id()); len(results) > 0 {
+		t.Fatalf("lookup on empty table returned %d results: %#v", len(results), results)
+	}
+
+	// Ensure the tester knows all nodes in lookupTestnet by IP.
+	for d, nn := range lookupTestnet.dists {
+		for i, key := range nn {
+			n := lookupTestnet.node(d, i)
+			test.getNode(key, &net.UDPAddr{IP: n.IP(), Port: n.UDP()})
+		}
+	}
+
+	// Seed table with initial node.
+	initialNode := lookupTestnet.node(256, 0)
+	fillTable(test.table, []*node{wrapNode(initialNode)})
+
+	// Start the lookup.
+	resultC := make(chan []*enode.Node, 1)
+	go func() {
+		resultC <- test.udp.Lookup(lookupTestnet.target.id())
+		test.close()
+	}()
+
+	// Answer lookup packets.
+	asked := make(map[enode.ID]bool)
+	for done := false; !done; {
+		done = test.waitPacketOut(func(p v5wire.Packet, to *net.UDPAddr, _ v5wire.Nonce) {
+			recipient, key := lookupTestnet.nodeByAddr(to)
+			switch p := p.(type) {
+			case *v5wire.Ping:
+				test.packetInFrom(key, to, &v5wire.Pong{ReqID: p.ReqID})
+			case *v5wire.Findnode:
+				if asked[recipient.ID()] {
+					t.Error("Asked node", recipient.ID(), "twice")
+				}
+				asked[recipient.ID()] = true
+				nodes := lookupTestnet.neighborsAtDistances(recipient, p.Distances, 16)
+				t.Logf("Got FINDNODE for %v, returning %d nodes", p.Distances, len(nodes))
+				for _, resp := range packNodes(p.ReqID, nodes) {
+					test.packetInFrom(key, to, resp)
+				}
+			}
+		})
+	}
+
+	// Verify result nodes.
+	results := <-resultC
+	checkLookupResults(t, lookupTestnet, results)
+}
+
+// This test checks the local node can be utilised to set key-values.
+func TestUDPv5_LocalNode(t *testing.T) {
+	t.Parallel()
+	var cfg Config
+	node := startLocalhostV5(t, cfg)
+	defer node.Close()
+	localNd := node.LocalNode()
+
+	// set value in node's local record
+	testVal := [4]byte{'A', 'B', 'C', 'D'}
+	localNd.Set(enr.WithEntry("testing", &testVal))
+
+	// retrieve the value from self to make sure it matches.
+	outputVal := [4]byte{}
+	if err := node.Self().Load(enr.WithEntry("testing", &outputVal)); err != nil {
+		t.Errorf("Could not load value from record: %v", err)
+	}
+	if testVal != outputVal {
+		t.Errorf("Wanted %#x to be retrieved from the record but instead got %#x", testVal, outputVal)
+	}
+}
+
+func TestUDPv5_PingWithIPV4MappedAddress(t *testing.T) {
+	t.Parallel()
+	test := newUDPV5Test(t)
+	defer test.close()
+
+	rawIP := net.IPv4(0xFF, 0x12, 0x33, 0xE5)
+	test.remoteaddr = &net.UDPAddr{
+		IP:   rawIP.To16(),
+		Port: 0,
+	}
+	remote := test.getNode(test.remotekey, test.remoteaddr).Node()
+	done := make(chan struct{}, 1)
+
+	// This handler will truncate the ipv4-mapped in ipv6 address.
+	go func() {
+		test.udp.handlePing(&v5wire.Ping{ENRSeq: 1}, remote.ID(), test.remoteaddr)
+		done <- struct{}{}
+	}()
+	test.waitPacketOut(func(p *v5wire.Pong, addr *net.UDPAddr, _ v5wire.Nonce) {
+		if len(p.ToIP) == net.IPv6len {
+			t.Error("Received untruncated ip address")
+		}
+		if len(p.ToIP) != net.IPv4len {
+			t.Errorf("Received ip address with incorrect length: %d", len(p.ToIP))
+		}
+		if !p.ToIP.Equal(rawIP) {
+			t.Errorf("Received incorrect ip address: wanted %s but received %s", rawIP.String(), p.ToIP.String())
+		}
+	})
+	<-done
+}
+
+// udpV5Test is the framework for all tests above.
+// It runs the UDPv5 transport on a virtual socket and allows testing outgoing packets.
+type udpV5Test struct {
+	t                   *testing.T
+	pipe                *dgramPipe
+	table               *Table
+	db                  *enode.DB
+	udp                 *UDPv5
+	localkey, remotekey *ecdsa.PrivateKey
+	remoteaddr          *net.UDPAddr
+	nodesByID           map[enode.ID]*enode.LocalNode
+	nodesByIP           map[string]*enode.LocalNode
+}
+
+// testCodec is the packet encoding used by protocol tests. This codec does not perform encryption.
+type testCodec struct {
+	test *udpV5Test
+	id   enode.ID
+	ctr  uint64
+}
+
+type testCodecFrame struct {
+	NodeID  enode.ID
+	AuthTag v5wire.Nonce
+	Ptype   byte
+	Packet  rlp.RawValue
+}
+
+func (c *testCodec) Encode(toID enode.ID, addr string, p v5wire.Packet, _ *v5wire.Whoareyou) ([]byte, v5wire.Nonce, error) {
+	c.ctr++
+	var authTag v5wire.Nonce
+	binary.BigEndian.PutUint64(authTag[:], c.ctr)
+
+	penc, _ := rlp.EncodeToBytes(p)
+	frame, err := rlp.EncodeToBytes(testCodecFrame{c.id, authTag, p.Kind(), penc})
+	return frame, authTag, err
+}
+
+func (c *testCodec) Decode(input []byte, addr string) (enode.ID, *enode.Node, v5wire.Packet, error) {
+	frame, p, err := c.decodeFrame(input)
+	if err != nil {
+		return enode.ID{}, nil, nil, err
+	}
+	return frame.NodeID, nil, p, nil
+}
+
+func (c *testCodec) decodeFrame(input []byte) (frame testCodecFrame, p v5wire.Packet, err error) {
+	if err = rlp.DecodeBytes(input, &frame); err != nil {
+		return frame, nil, fmt.Errorf("invalid frame: %v", err)
+	}
+	switch frame.Ptype {
+	case v5wire.UnknownPacket:
+		dec := new(v5wire.Unknown)
+		err = rlp.DecodeBytes(frame.Packet, &dec)
+		p = dec
+	case v5wire.WhoareyouPacket:
+		dec := new(v5wire.Whoareyou)
+		err = rlp.DecodeBytes(frame.Packet, &dec)
+		p = dec
+	default:
+		p, err = v5wire.DecodeMessage(frame.Ptype, frame.Packet)
+	}
+	return frame, p, err
+}
+
+func newUDPV5Test(t *testing.T) *udpV5Test {
+	test := &udpV5Test{
+		t:          t,
+		pipe:       newpipe(),
+		localkey:   newkey(),
+		remotekey:  newkey(),
+		remoteaddr: &net.UDPAddr{IP: net.IP{10, 0, 1, 99}, Port: 30303},
+		nodesByID:  make(map[enode.ID]*enode.LocalNode),
+		nodesByIP:  make(map[string]*enode.LocalNode),
+	}
+	test.db, _ = enode.OpenDB("")
+	ln := enode.NewLocalNode(test.db, test.localkey)
+	ln.SetStaticIP(net.IP{10, 0, 0, 1})
+	ln.Set(enr.UDP(30303))
+	test.udp, _ = ListenV5(test.pipe, ln, Config{
+		PrivateKey:   test.localkey,
+		Log:          Logger(t, log.LvlTrace),
+		ValidSchemes: enode.ValidSchemesForTesting,
+	})
+	test.udp.codec = &testCodec{test: test, id: ln.ID()}
+	test.table = test.udp.tab
+	test.nodesByID[ln.ID()] = ln
+	// Wait for initial refresh so the table doesn't send unexpected findnode.
+	<-test.table.initDone
+	return test
+}
+
+// handles a packet as if it had been sent to the transport.
+func (test *udpV5Test) packetIn(packet v5wire.Packet) {
+	test.t.Helper()
+	test.packetInFrom(test.remotekey, test.remoteaddr, packet)
+}
+
+// handles a packet as if it had been sent to the transport by the key/endpoint.
+func (test *udpV5Test) packetInFrom(key *ecdsa.PrivateKey, addr *net.UDPAddr, packet v5wire.Packet) {
+	test.t.Helper()
+
+	ln := test.getNode(key, addr)
+	codec := &testCodec{test: test, id: ln.ID()}
+	enc, _, err := codec.Encode(test.udp.Self().ID(), addr.String(), packet, nil)
+	if err != nil {
+		test.t.Errorf("%s encode error: %v", packet.Name(), err)
+	}
+	if test.udp.dispatchReadPacket(addr, enc) {
+		<-test.udp.readNextCh // unblock UDPv5.dispatch
+	}
+}
+
+// getNode ensures the test knows about a node at the given endpoint.
+func (test *udpV5Test) getNode(key *ecdsa.PrivateKey, addr *net.UDPAddr) *enode.LocalNode {
+	id := encodePubkey(&key.PublicKey).id()
+	ln := test.nodesByID[id]
+	if ln == nil {
+		db, _ := enode.OpenDB("")
+		ln = enode.NewLocalNode(db, key)
+		ln.SetStaticIP(addr.IP)
+		ln.Set(enr.UDP(addr.Port))
+		test.nodesByID[id] = ln
+	}
+	test.nodesByIP[string(addr.IP)] = ln
+	return ln
+}
+
+// waitPacketOut waits for the next output packet and handles it using the given 'validate'
+// function. The function must be of type func (X, *net.UDPAddr, v5wire.Nonce) where X is
+// assignable to packetV5.
+func (test *udpV5Test) waitPacketOut(validate interface{}) (closed bool) {
+	test.t.Helper()
+
+	fn := reflect.ValueOf(validate)
+	exptype := fn.Type().In(0)
+
+	dgram, err := test.pipe.receive()
+	if err == errClosed {
+		return true
+	}
+	if err == ErrTimeout {
+		test.t.Fatalf("timed out waiting for %v", exptype)
+		return false
+	}
+	ln := test.nodesByIP[string(dgram.to.IP)]
+	if ln == nil {
+		test.t.Fatalf("attempt to send to non-existing node %v", &dgram.to)
+		return false
+	}
+	codec := &testCodec{test: test, id: ln.ID()}
+	frame, p, err := codec.decodeFrame(dgram.data)
+	if err != nil {
+		test.t.Errorf("sent packet decode error: %v", err)
+		return false
+	}
+	if !reflect.TypeOf(p).AssignableTo(exptype) {
+		test.t.Errorf("sent packet type mismatch, got: %v, want: %v", reflect.TypeOf(p), exptype)
+		return false
+	}
+	fn.Call([]reflect.Value{reflect.ValueOf(p), reflect.ValueOf(&dgram.to), reflect.ValueOf(frame.AuthTag)})
+	return false
+}
+
+func (test *udpV5Test) close() {
+	test.t.Helper()
+
+	test.udp.Close()
+	test.db.Close()
+	for id, n := range test.nodesByID {
+		if id != test.udp.Self().ID() {
+			n.Database().Close()
+		}
+	}
+	if len(test.pipe.queue) != 0 {
+		test.t.Fatalf("%d unmatched UDP packets in queue", len(test.pipe.queue))
+	}
+}


### PR DESCRIPTION
The discv5 implementation only allows a single concurrent request to another peer. However, there seems no inherent reason as each request contains a random request ID that allows matching the responses with the requests.

This PR also adds back the discv5/discv4 test cases.