### PR TITLE
Celestia Mainnet Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@ A DHT crawler and monitor that tracks the liveness of peers. The crawler connect
 - [Kusama](https://kusama.network/)
 - [Rococo](https://substrate.io/developers/rococo-network/)
 - [Westend](https://wiki.polkadot.network/docs/maintain-networks#westend-test-network)
-- [Arabica](https://github.com/celestiaorg/celestia-node/blob/9c0a5fb0626ada6e6cdb8bcd816d01a3aa5043ad/nodebuilder/p2p/bootstrap.go#L40)
-- [Blockspace Race](https://github.com/celestiaorg/celestia-node/blob/9c0a5fb0626ada6e6cdb8bcd816d01a3aa5043ad/nodebuilder/p2p/bootstrap.go#L51C11-L51C11)
 - [Celestia](https://celestia.org/) - [_Mainnet_](https://blog.celestia.org/celestia-mainnet-is-live/)
-
+- [Celestia](https://celestia.org/) - [_Arabica_](https://github.com/celestiaorg/celestia-node/blob/9c0a5fb0626ada6e6cdb8bcd816d01a3aa5043ad/nodebuilder/p2p/bootstrap.go#L40)
+- [Celestia](https://celestia.org/) - [_Mocha_](https://docs.celestia.org/nodes/mocha-testnet)
 
 _The crawler was:_
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A DHT crawler and monitor that tracks the liveness of peers. The crawler connect
 - [Westend](https://wiki.polkadot.network/docs/maintain-networks#westend-test-network)
 - [Arabica](https://github.com/celestiaorg/celestia-node/blob/9c0a5fb0626ada6e6cdb8bcd816d01a3aa5043ad/nodebuilder/p2p/bootstrap.go#L40)
 - [Blockspace Race](https://github.com/celestiaorg/celestia-node/blob/9c0a5fb0626ada6e6cdb8bcd816d01a3aa5043ad/nodebuilder/p2p/bootstrap.go#L51C11-L51C11)
+- [Celestia](https://celestia.org/) - [_Mainnet_](https://blog.celestia.org/celestia-mainnet-is-live/)
 
 
 _The crawler was:_

--- a/pkg/config/bootstrap.go
+++ b/pkg/config/bootstrap.go
@@ -151,20 +151,21 @@ var (
 	}
 
 	// BootstrapPeersArabica extracted from:
-	//   https://github.com/celestiaorg/celestia-node/blob/9c0a5fb0626ada6e6cdb8bcd816d01a3aa5043ad/nodebuilder/p2p/bootstrap.go#L39
+	//   https://github.com/celestiaorg/celestia-node/blob/3fde8c9acb90bb9d4d1abbdc2c5917d7f3693388/nodebuilder/p2p/bootstrap.go#L51
 	BootstrapPeersArabica = []string{
-		"/dns4/limani.celestia-devops.dev/tcp/2121/p2p/12D3KooWDgG69kXfmSiHjUErN2ahpUC1SXpSfB2urrqMZ6aWC8NS",
-		"/dns4/marsellesa.celestia-devops.dev/tcp/2121/p2p/12D3KooWHr2wqFAsMXnPzpFsgxmePgXb8BqpkePebwUgLyZc95bd",
-		"/dns4/parainem.celestia-devops.dev/tcp/2121/p2p/12D3KooWHX8xpwg8qkP7kLKmKGtgZvmsopvgxc6Fwtu665QC7G8q",
-		"/dns4/kaarina.celestia-devops.dev/tcp/2121/p2p/12D3KooWN6fzdt4sG5QfWRPn4kwCQBdkt7TDNQkWsUymAwKrmvUs",
+		"/dns4/da-bridge.celestia-arabica-10.com/tcp/2121/p2p/12D3KooWM3e9MWtyc8GkP8QRt74Riu17QuhGfZMytB2vq5NwkWAu",
+		"/dns4/da-bridge-2.celestia-arabica-10.com/tcp/2121/p2p/12D3KooWKj8mcdiBGxQRe1jqhaMnh2tGoC3rPDmr5UH2q8H4WA9M",
+		"/dns4/da-full-1.celestia-arabica-10.com/tcp/2121/p2p/12D3KooWBWkgmN7kmJSFovVrCjkeG47FkLGq7yEwJ2kEqNKCsBYk",
+		"/dns4/da-full-2.celestia-arabica-10.com/tcp/2121/p2p/12D3KooWRByRF67a2kVM2j4MP5Po3jgTw7H2iL2Spu8aUwPkrRfP",
 	}
 
 	// BootstrapPeersMocha extracted from:
-	//   https://github.com/celestiaorg/celestia-node/blob/9c0a5fb0626ada6e6cdb8bcd816d01a3aa5043ad/nodebuilder/p2p/bootstrap.go#L39
+	//   https://github.com/celestiaorg/celestia-node/blob/3fde8c9acb90bb9d4d1abbdc2c5917d7f3693388/nodebuilder/p2p/bootstrap.go#L57
 	BootstrapPeersMocha = []string{
-		"/dns4/andromeda.celestia-devops.dev/tcp/2121/p2p/12D3KooWKvPXtV1yaQ6e3BRNUHa5Phh8daBwBi3KkGaSSkUPys6D",
-		"/dns4/libra.celestia-devops.dev/tcp/2121/p2p/12D3KooWK5aDotDcLsabBmWDazehQLMsDkRyARm1k7f1zGAXqbt4",
-		"/dns4/norma.celestia-devops.dev/tcp/2121/p2p/12D3KooWHYczJDVNfYVkLcNHPTDKCeiVvRhg8Q9JU3bE3m9eEVyY",
+		"/dns4/da-bridge-mocha-4.celestia-mocha.com/tcp/2121/p2p/12D3KooWCBAbQbJSpCpCGKzqz3rAN4ixYbc63K68zJg9aisuAajg",
+		"/dns4/da-bridge-mocha-4-2.celestia-mocha.com/tcp/2121/p2p/12D3KooWK6wJkScGQniymdWtBwBuU36n6BRXp9rCDDUD6P5gJr3G",
+		"/dns4/da-full-1-mocha-4.celestia-mocha.com/tcp/2121/p2p/12D3KooWCUHPLqQXZzpTx1x3TAsdn3vYmTNDhzg66yG8hqoxGGN8",
+		"/dns4/da-full-2-mocha-4.celestia-mocha.com/tcp/2121/p2p/12D3KooWR6SHsXPkkvhCRn6vp1RqSefgaT1X1nMNvrVjU2o3GoYy",
 	}
 
 	// BootstrapPeersBlockspaceRace extracted from:

--- a/pkg/config/bootstrap.go
+++ b/pkg/config/bootstrap.go
@@ -136,6 +136,20 @@ var (
 		"/dns/boot-westend.metaspan.io/tcp/33016/wss/p2p/12D3KooWNTau7iG4G9cUJSwwt2QJP1W88pUf2SgqsHjRU2RL8pfa",
 	}
 
+	// BootstrapPeersCelestia extracted from:
+	//   https://github.com/celestiaorg/celestia-node/blob/3fde8c9acb90bb9d4d1abbdc2c5917d7f3693388/nodebuilder/p2p/bootstrap.go#L39
+	BootstrapPeersCelestia = []string{
+		"/dns4/da-bridge-1.celestia-bootstrap.net/tcp/2121/p2p/12D3KooWSqZaLcn5Guypo2mrHr297YPJnV8KMEMXNjs3qAS8msw8",
+		"/dns4/da-bridge-2.celestia-bootstrap.net/tcp/2121/p2p/12D3KooWQpuTFELgsUypqp9N4a1rKBccmrmQVY8Em9yhqppTJcXf",
+		"/dns4/da-bridge-3.celestia-bootstrap.net/tcp/2121/p2p/12D3KooWSGa4huD6ts816navn7KFYiStBiy5LrBQH1HuEahk4TzQ",
+		"/dns4/da-bridge-4.celestia-bootstrap.net/tcp/2121/p2p/12D3KooWHBXCmXaUNat6ooynXG837JXPsZpSTeSzZx6DpgNatMmR",
+		"/dns4/da-bridge-5.celestia-bootstrap.net/tcp/2121/p2p/12D3KooWDGTBK1a2Ru1qmnnRwP6Dmc44Zpsxi3xbgFk7ATEPfmEU",
+		"/dns4/da-bridge-6.celestia-bootstrap.net/tcp/2121/p2p/12D3KooWLTUFyf3QEGqYkHWQS2yCtuUcL78vnKBdXU5gABM1YDeH",
+		"/dns4/da-full-1.celestia-bootstrap.net/tcp/2121/p2p/12D3KooWKZCMcwGCYbL18iuw3YVpAZoyb1VBGbx9Kapsjw3soZgr",
+		"/dns4/da-full-2.celestia-bootstrap.net/tcp/2121/p2p/12D3KooWE3fmRtHgfk9DCuQFfY3H3JYEnTU3xZozv1Xmo8KWrWbK",
+		"/dns4/da-full-3.celestia-bootstrap.net/tcp/2121/p2p/12D3KooWK6Ftsd4XsWCsQZgZPNhTrE5urwmkoo5P61tGvnKmNVyv",
+	}
+
 	// BootstrapPeersArabica extracted from:
 	//   https://github.com/celestiaorg/celestia-node/blob/9c0a5fb0626ada6e6cdb8bcd816d01a3aa5043ad/nodebuilder/p2p/bootstrap.go#L39
 	BootstrapPeersArabica = []string{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -244,10 +244,10 @@ func ConfigureNetwork(network string) (*cli.StringSlice, *cli.StringSlice, error
 		protocols = cli.NewStringSlice("/celestia/celestia/kad/1.0.0")
 	case NetworkArabica:
 		bootstrapPeers = cli.NewStringSlice(BootstrapPeersArabica...)
-		protocols = cli.NewStringSlice("/celestia/arabica-6/kad/1.0.0")
+		protocols = cli.NewStringSlice("/celestia/arabica-10/kad/1.0.0") // the `-10` suffix seems to be variable
 	case NetworkMocha:
 		bootstrapPeers = cli.NewStringSlice(BootstrapPeersMocha...)
-		protocols = cli.NewStringSlice("/celestia/mocha/kad/1.0.0")
+		protocols = cli.NewStringSlice("/celestia/mocha-4/kad/1.0.0") // the `-4` suffix seems to be variable
 	case NetworkBlockRa:
 		bootstrapPeers = cli.NewStringSlice(BootstrapPeersBlockspaceRace...)
 		protocols = cli.NewStringSlice("/celestia/blockspacerace-0/kad/1.0.0")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,7 @@ const (
 	NetworkPolkadot Network = "POLKADOT"
 	NetworkRococo   Network = "ROCOCO"
 	NetworkWestend  Network = "WESTEND"
+	NetworkCelestia Network = "CELESTIA"
 	NetworkArabica  Network = "ARABICA"
 	NetworkMocha    Network = "MOCHA"
 	NetworkBlockRa  Network = "BLOCKSPACE_RACE"
@@ -36,6 +37,7 @@ func Networks() []Network {
 		NetworkPolkadot,
 		NetworkRococo,
 		NetworkWestend,
+		NetworkCelestia,
 		NetworkArabica,
 		NetworkMocha,
 		NetworkBlockRa,
@@ -237,6 +239,9 @@ func ConfigureNetwork(network string) (*cli.StringSlice, *cli.StringSlice, error
 	case NetworkWestend:
 		bootstrapPeers = cli.NewStringSlice(BootstrapPeersWestend...)
 		protocols = cli.NewStringSlice("/wnd2/kad")
+	case NetworkCelestia:
+		bootstrapPeers = cli.NewStringSlice(BootstrapPeersCelestia...)
+		protocols = cli.NewStringSlice("/celestia/celestia/kad/1.0.0")
 	case NetworkArabica:
 		bootstrapPeers = cli.NewStringSlice(BootstrapPeersArabica...)
 		protocols = cli.NewStringSlice("/celestia/arabica-6/kad/1.0.0")

--- a/pkg/core/handler_crawl.go
+++ b/pkg/core/handler_crawl.go
@@ -206,7 +206,7 @@ func (h *CrawlHandler[I]) HandleWriteResult(result Result[WriteResult]) {
 // TotalErrors counts the total amount of errors - equivalent to undialable peers during this crawl.
 func (h *CrawlHandler[I]) TotalErrors() int {
 	sum := 0
-	for _, count := range h.CrawlErrs {
+	for _, count := range h.ConnErrs {
 		sum += count
 	}
 	return sum

--- a/pkg/core/queue.go
+++ b/pkg/core/queue.go
@@ -2,8 +2,6 @@ package core
 
 import (
 	"container/heap"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // An item is something we manage in a priority queue.
@@ -93,9 +91,6 @@ func (tq *PriorityQueue[T]) Update(key string, value T, priority int) bool {
 	item, found := tq.lookup[key]
 	if !found {
 		return false
-	}
-	if item.priority < priority {
-		log.Error("FIXEd")
 	}
 	item.priority = priority
 	item.value = value


### PR DESCRIPTION
## Changelog

- This PR adds support for Celestia Mainnet, which was launched ~2w ago by adding the `CELESTIA` network key. A network crawl only takes a few seconds.
- This PR also updates the Arabica and Mocha network defaults (though I learned that this seems to be a moving target)

@wondertan do the following numbers make sense?

```
INFO[0024] Crawl summary:                               
INFO[0024]                                              
INFO[0024] Dial Error                                    count=13 value=connection_refused
INFO[0024] Dial Error                                    count=8 value=connection_reset_by_peer
INFO[0024] Dial Error                                    count=24 value=io_timeout
INFO[0024] Dial Error                                    count=11 value=no_public_ip
INFO[0024]                                              
INFO[0024]                                              
INFO[0024] Agent                                         count=80 value=celestia-celestia
INFO[0024] Agent                                         count=56 value=
INFO[0024]                                              
INFO[0024] Protocol                                      count=61 value=/celestia/shrex/eds/v0.0.1
INFO[0024] Protocol                                      count=80 value=/ipfs/id/push/1.0.0
INFO[0024] Protocol                                      count=80 value=/celestia/header-ex/v0.0.3
INFO[0024] Protocol                                      count=80 value=/celestia/celestia/ipfs/bitswap/1.2.0
INFO[0024] Protocol                                      count=80 value=/celestia/fraud/v0.0.1
INFO[0024] Protocol                                      count=80 value=/celestia/celestia/ipfs/bitswap/1.0.0
INFO[0024] Protocol                                      count=80 value=/celestia/celestia/ipfs/bitswap
INFO[0024] Protocol                                      count=80 value=/ipfs/ping/1.0.0
INFO[0024] Protocol                                      count=80 value=/floodsub/1.0.0
INFO[0024] Protocol                                      count=55 value=/libp2p/autonat/1.0.0
INFO[0024] Protocol                                      count=61 value=/celestia/shrex/nd/v0.0.3
INFO[0024] Protocol                                      count=80 value=/ipfs/id/1.0.0
INFO[0024] Protocol                                      count=80 value=/meshsub/1.1.0
INFO[0024] Protocol                                      count=80 value=/celestia/celestia/ipfs/bitswap/1.1.0
INFO[0024] Protocol                                      count=80 value=/celestia/celestia/kad/1.0.0
INFO[0024]                                              
INFO[0024] Finished crawl                                crawlDuration=24.491062084s crawledPeers=136 dialablePeers=80 undialablePeers=56

```

It would be great to have proper versioning in the agent version instead of just `celestia-celestia` :+1:

Full crawl results:

[2023-11-14_neighbors.json](https://github.com/dennis-tra/nebula/files/13348112/2023-11-14_neighbors.json)
[2023-11-14_visits.json](https://github.com/dennis-tra/nebula/files/13348114/2023-11-14_visits.json)
[2023-11-14_crawl_properties.json](https://github.com/dennis-tra/nebula/files/13348110/2023-11-14_crawl_properties.json)
[2023-11-14_crawl.json](https://github.com/dennis-tra/nebula/files/13348111/2023-11-14_crawl.json)
