### PR TITLE
fix: store reported discv5 listen maddrs in the DB

### DIFF
--- a/discv5/crawler.go
+++ b/discv5/crawler.go
@@ -86,6 +86,10 @@ func (c *Crawler) Work(ctx context.Context, task PeerInfo) (core.CrawlResult[Pee
 		log.WithError(err).WithField("properties", properties).Warnln("Could not marshal peer properties")
 	}
 
+	if len(libp2pResult.ListenAddrs) > 0 {
+		task.maddrs = libp2pResult.ListenAddrs
+	}
+
 	cr := core.CrawlResult[PeerInfo]{
 		CrawlerID:           c.id,
 		Info:                task,
@@ -220,9 +224,8 @@ func (c *Crawler) crawlLibp2p(ctx context.Context, pi PeerInfo) chan Libp2pResul
 				}
 			}
 
-			// Update pi maddrs to include all listen addresses
-			pi.maddrs = ps.Addrs(pi.ID())
-			result.ListenAddrs = pi.maddrs
+			// Extract listen addresses
+			result.ListenAddrs = ps.Addrs(pi.ID())
 		}
 
 		// if there was a connection error, parse it to a known one

--- a/discv5/crawler.go
+++ b/discv5/crawler.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/libp2p/go-libp2p/p2p/host/basic"
+	basichost "github.com/libp2p/go-libp2p/p2p/host/basic"
 	ma "github.com/multiformats/go-multiaddr"
 	log "github.com/sirupsen/logrus"
 	"go.uber.org/atomic"
@@ -220,8 +220,9 @@ func (c *Crawler) crawlLibp2p(ctx context.Context, pi PeerInfo) chan Libp2pResul
 				}
 			}
 
-			// Extract listen addresses
-			result.ListenAddrs = ps.Addrs(pi.ID())
+			// Update pi maddrs to include all listen addresses
+			pi.maddrs = ps.Addrs(pi.ID())
+			result.ListenAddrs = pi.maddrs
 		}
 
 		// if there was a connection error, parse it to a known one


### PR DESCRIPTION
Nebula used to store only the discv5 maddrs crafted from the ENR in the DB. It should store all reported multiaddresses (including quic).