### PR TITLE
discv5: only store crawl error if no query succeeded

### DIFF
--- a/discv5/crawler.go
+++ b/discv5/crawler.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/libp2p/go-libp2p/p2p/host/basic"
+	basichost "github.com/libp2p/go-libp2p/p2p/host/basic"
 	ma "github.com/multiformats/go-multiaddr"
 	log "github.com/sirupsen/logrus"
 	"go.uber.org/atomic"
@@ -24,6 +24,8 @@ import (
 	"github.com/dennis-tra/nebula-crawler/db/models"
 	"github.com/dennis-tra/nebula-crawler/discvx"
 )
+
+const MAX_CRAWL_RETRY_AFTER_TIMEOUT = 2 // magic
 
 type CrawlerConfig struct {
 	DialTimeout  time.Duration
@@ -460,18 +462,19 @@ func (c *Crawler) crawlDiscV5(ctx context.Context, pi PeerInfo) chan DiscV5Resul
 			result.RespondedAt = &now
 		}
 
+		success := false
 		// loop through the buckets sequentially because discv5 is also doing that
 		// internally, so we won't gain much by spawning multiple parallel go
 		// routines here. Stop the process as soon as we have received a timeout and
 		// don't let the following calls time out as well.
-		for i := 0; i <= discvx.NBuckets; i++ { // 15 is maximum
+		for i := 0; i <= discvx.NBuckets; i++ { // 17 is maximum
 			var neighbors []*enode.Node
 			neighbors, err = c.listener.FindNode(pi.Node, []uint{uint(discvx.HashBits - i)})
 			if err != nil {
 
 				if errors.Is(err, discvx.ErrTimeout) {
 					timeouts += 1
-					if timeouts < 2 {
+					if timeouts < MAX_CRAWL_RETRY_AFTER_TIMEOUT {
 						continue
 					}
 				}
@@ -480,6 +483,8 @@ func (c *Crawler) crawlDiscV5(ctx context.Context, pi PeerInfo) chan DiscV5Resul
 				err = fmt.Errorf("getting closest peer with CPL %d: %w", i, err)
 				break
 			}
+			success = true
+			timeouts = 0
 
 			if result.RespondedAt == nil {
 				now := time.Now()
@@ -508,6 +513,11 @@ func (c *Crawler) crawlDiscV5(ctx context.Context, pi PeerInfo) chan DiscV5Resul
 
 		for _, n := range allNeighbors {
 			result.RoutingTable.Neighbors = append(result.RoutingTable.Neighbors, n)
+		}
+
+		// if we have at least a successful result, delete error
+		if success && result.Error != nil {
+			result.Error = nil
 		}
 
 		// if there was a connection error, parse it to a known one


### PR DESCRIPTION
Until now, a visit has a crawl error as soon as 1 request fails. 

Change the behavior to log a crawl error only if all requests fail.

Note that from the code, as long as there is an error with a bucket, all the next buckets will NOT be queried. So the crawl considers that all requests have failed.