### PR TITLE
fix: crawl_error detection

### DIFF
--- a/discv5/crawler.go
+++ b/discv5/crawler.go
@@ -520,7 +520,7 @@ func (c *Crawler) crawlDiscV5(ctx context.Context, pi PeerInfo) chan DiscV5Resul
 		// if we have at least a successful result, delete error
 		// bitwise operation checks whether errorBits is a power of 2 minus 1,
 		// if not, then there was at least one successful result
-		if result.Error != nil && (result.RoutingTable.ErrorBits&(result.RoutingTable.ErrorBits+1)) == 0 {
+		if result.Error != nil && (result.RoutingTable.ErrorBits&(result.RoutingTable.ErrorBits+1)) != 0 {
 			result.Error = nil
 		}
 


### PR DESCRIPTION
If all runs of the loop failed, then `ErrorBits` is a power of two minus one, and we should keep the `result.Error`. Otherwise, at least one iteration was successful, set `result.Error` to `nil`.