### PR TITLE
Fix Gorelease at Github Actions 

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -17,6 +17,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install compiling essentials
+        run: | 
+          sudo apt-get install -y gcc-multilib
+
       - name: Setting up Go
         uses: actions/setup-go@v4
 


### PR DESCRIPTION
# Description
Coming from Issue #60 and from the previous fix attempt at #62 

It seems that the Ubuntu-Latest machine spawned to create the binaries is unable to find C dependencies to build the binaries. This PR aims to fix that.