### PR TITLE
Specify CCompiler binaries for each OS and Arch

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -17,6 +17,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install compiling essentials
+        run: | 
+          sudo apt-get install -y gcc-multilib
+
       - name: Setting up Go
         uses: actions/setup-go@v4
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,7 +20,37 @@ builds:
       - linux
       - windows
       - darwin
-
+    overrides:
+      - goos: darwin
+        goarch: amd64
+        env:
+          - CC=o64-clang
+          - CXX=o64-clang++
+      - goos: darwin
+        goarch: arm64
+        env:
+          - CC=oa64-clang
+          - CXX=oa64-clang++
+      - goos: linux
+        goarch: amd64
+        env:
+          - CC=x86_64-linux-gnu-gcc
+          - CXX=x86_64-linux-gnu-g++
+      - goos: linux
+        goarch: arm64
+        env:
+          - CC=aarch64-linux-gnu-gcc
+          - CXX=aarch64-linux-gnu-g++
+      - goos: windows
+        goarch: amd64
+        env:
+          - CC=x86_64-w64-mingw32-gcc
+          - CXX=x86_64-w64-mingw32-g++	
+      - goos: windows
+        goarch: arm64
+        env:
+          - CC=aarch64-w64-mingw32-gcc
+          - CXX=aarch64-w64-mingw32-g++
 release:
   draft: true
 


### PR DESCRIPTION
# Description
#63 fix the GCC missing dependencies to compile the binaries. However, it was missing the specific CC (C Compiler binaries for each of the OS and Arch we want to compile for)

This PR specifies those missing binaries.