### PR TITLE
Add ghcr.io/gorelease-cross docker to cross-compile binaries

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -17,18 +17,26 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install compiling essentials
-        run: | 
-          sudo apt-get install -y gcc-multilib
-
       - name: Setting up Go
         uses: actions/setup-go@v4
+        with:
+          go-version: '1.19'
+
+      - name: Install cross-compiler for linux/arm64
+        run: sudo apt-get -y install gcc-aarch64-linux-gnu
+
+      - name: Install make
+        run: sudo apt-get -y install make
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
       - name: Running GoReleaser
-        uses: goreleaser/goreleaser-action@v5
-        with:
-          distribution: goreleaser
-          version: latest
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: | 
+          docker run --rm \
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            -v ${{ github.workspace }}:/workspace \
+            -w /workspace \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            ghcr.io/goreleaser/goreleaser-cross:v1.19.6 build --clean --config .goreleaser.yaml
+

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,52 +5,83 @@
 # Feel free to remove those if you don't want/need to use them.
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
-
-version: 1
-
 project_name: nebula
 
+before:
+  hooks:
+    - go mod tidy
+    - go run ./cmd/prefix/gen.go  
 builds:
-  - id: nebula
+  - id: linux-amd64
     main: ./cmd/nebula
-    binary: nebula
     env:
       - CGO_ENABLED=1
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+    binary: nebula-linux-amd64
     goos:
-      - linux
-      - windows
-      - darwin
-    overrides:
-      - goos: darwin
-        goarch: amd64
-        env:
-          - CC=o64-clang
-          - CXX=o64-clang++
-      - goos: darwin
-        goarch: arm64
-        env:
-          - CC=oa64-clang
-          - CXX=oa64-clang++
-      - goos: linux
-        goarch: amd64
-        env:
-          - CC=x86_64-linux-gnu-gcc
-          - CXX=x86_64-linux-gnu-g++
-      - goos: linux
-        goarch: arm64
-        env:
-          - CC=aarch64-linux-gnu-gcc
-          - CXX=aarch64-linux-gnu-g++
-      - goos: windows
-        goarch: amd64
-        env:
-          - CC=x86_64-w64-mingw32-gcc
-          - CXX=x86_64-w64-mingw32-g++	
-      - goos: windows
-        goarch: arm64
-        env:
-          - CC=aarch64-w64-mingw32-gcc
-          - CXX=aarch64-w64-mingw32-g++
+    - linux
+    goarch: 
+    - amd64
+    ldflags:
+      - -s -w
+
+  - id: linux-arm64
+    main: ./cmd/nebula
+    env:
+      - CGO_ENABLED=1
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+    binary: nebula-linux-arm64
+    goos: 
+    - linux
+    goarch: 
+    - arm64
+    ldflags:
+      - -s -w
+
+  - id: windows-amd64
+    main: ./cmd/nebula
+    env:
+      - CGO_ENABLED=1
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+    binary: nebula-win-amd64
+    goos:
+    - windows
+    goarch:
+    - amd64
+    ldflags:
+      - -s -w
+
+  - id: darwin-amd64
+    main: ./cmd/nebula
+    env:
+      - CGO_ENABLED=1
+      - CC=o64-clang
+      - CXX=o64-clang++
+    binary: nebula-darwin-amd64
+    goos:
+    - darwin
+    goarch:
+    - amd64
+    ldflags:
+      - -s -w
+
+  - id: darwin-arm64
+    main: ./cmd/nebula
+    env:
+      - CGO_ENABLED=1
+      - CC=o64-clang
+      - CXX=o64-clang++
+    binary: nebula-darwin-arm64
+    goos:
+    - darwin
+    goarch:
+    - arm64
+    ldflags:
+      - -s -w
+
 release:
   draft: true
 


### PR DESCRIPTION
# Description
The compilation of Nebula requires some CGO dependencies, which heavily complicate the cross-compilation efforts. This PR aims to solve #60 using the Docker images provided by [goreleaser/goreleaser-cross](https://github.com/goreleaser/goreleaser-cross)

_NOTE: Super important to rely on the `ghcr.io/gorelease-cross` images, as there are some C libs missing at the DockerHub images._ :(

# Proof of Success 
The compilation works fine locally (with the listed GOOS and GOARCH) when running:
```
docker run --rm \
    -v ./:/workspace \
    -w /workspace \
    -v /var/run/docker.sock:/var/run/docker.sock \
    ghcr.io/goreleaser/goreleaser-cross:v1.19.6 build --snapshot --clean --config .goreleaser.yaml
```
which reports:
```
  • starting build...
  • loading config file                              file=.goreleaser.yaml
  • loading environment variables
  • getting and validating git state
    • building...                                    commit=a38f2d58da9ea1b7f093c5719db3420ad27d9867 latest tag=2.2.1
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • running before hooks
    • running                                        hook=go mod tidy
    • running                                        hook=go run ./cmd/prefix/gen.go
    • took: 17s
  • snapshotting
    • building snapshot...                           version=2.2.1-SNAPSHOT-a38f2d5
  • checking distribution directory
    • cleaning dist
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/darwin-arm64_darwin_arm64/nebula-darwin-arm64
    • building                                       binary=dist/darwin-amd64_darwin_amd64_v1/nebula-darwin-amd64
    • building                                       binary=dist/linux-arm64_linux_arm64/nebula-linux-arm64
    • building                                       binary=dist/linux-amd64_linux_amd64_v1/nebula-linux-amd64
    • building                                       binary=dist/windows-amd64_windows_amd64_v1/nebula-win-amd64.exe
    • took: 3m32s
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • build succeeded after 3m49s
```
 Just hoping that there is nothing broken at the GitHub Actions integration (fingerscrossed)

Sorry for the spam @dennis-tra , Let me know if there is anything easier/less spammer to try out the github-actions integrations :(