### PR TITLE
Make release of resulting dist/binaries from github actions

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -38,5 +38,5 @@ jobs:
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            ghcr.io/goreleaser/goreleaser-cross:v1.19.6 build --clean --config .goreleaser.yaml
+            ghcr.io/goreleaser/goreleaser-cross:v1.19.6 release --clean --config .goreleaser.yaml
 


### PR DESCRIPTION
After successfully cross-compiling nebula for other GOOS and GOARCHs, only changing the missing `release` flag at the `goreleaser` GitHub actions is needed (side effect from the local testing)