### PR TITLE
fix: crawlID should not be n-1 during ensurePartition

### DIFF
--- a/db/client_db.go
+++ b/db/client_db.go
@@ -235,7 +235,7 @@ func (c *DBClient) ensurePartitions(ctx context.Context, baseDate time.Time) {
 	}
 	maxCrawlID := 0
 	if crawl != nil {
-		maxCrawlID = crawl.ID
+		maxCrawlID = crawl.ID + 1
 	}
 
 	neighborsPartitionSize := 1000


### PR DESCRIPTION
As far as I understand, the db initialization happens at the start of the crawl.

When the db is initialized, this is where the [ensurePartitions](https://github.com/dennis-tra/nebula/blob/d88a08f2b6492d3acc42b79a1a72db1c752b9d65/db/client_db.go#L213) happens. However, for each start of the crawl, we do not have the current crawl ID until after the crawl actually starts, so the previous crawl ID is the max ID.