### PR TITLE
Update Avail bootnodes

### DIFF
--- a/config/bootstrap.go
+++ b/config/bootstrap.go
@@ -229,21 +229,18 @@ var (
 		"enr:-Le4QLoE1wFHSlGcm48a9ZESb_MRLqPPu6G0vHqu4MaUcQNDHS69tsy-zkN0K6pglyzX8m24mkb-LtBcbjAYdP1uxm4BhGV0aDKQabfZdAQBcAAAAQAAAAAAAIJpZIJ2NIJpcIQ5gR6Wg2lwNpAgAUHQBwEQAAAAAAAAADR-iXNlY3AyNTZrMaEDPMSNdcL92uNIyCsS177Z6KTXlbZakQqxv3aQcWawNXeDdWRwgiMohHVkcDaCI4I",
 	}
 
-	// BootstrapPeersGoldbergLightClient Avail network extracted from:
-	//   https://github.com/availproject/light-client-lib/blob/e5cb20f092951e15436bc21a2ac1f97c10d6a800/src/types.rs#L586C6-L586C72
-	BootstrapPeersGoldbergLightClient = []string{
-		"/dns/bootnode.1.lightclient.goldberg.avail.tools/tcp/37000/p2p/12D3KooWBkLsNGaD3SpMaRWtAmWVuiZg1afdNSPbtJ8M8r9ArGRT",
-	}
-
-	// BootstrapPeersGoldbergFullNode Avail network extracted from:
-	//   https://github.com/availproject/avail/blob/e976c560ee3f8c7d36d9fbec8e98c29283f1aa34/misc/genesis/testnet.goldberg.chain.json#L5
-	BootstrapPeersGoldbergFullNode = []string{
-		"/dns/bootnode-001.goldberg.avail.tools/tcp/30333/p2p/12D3KooWCVqFvrP3UJ1S338Gb8SHvEQ1xpENLb45Dbynk4hu1XGN",
-		"/dns/bootnode-002.goldberg.avail.tools/tcp/30333/p2p/12D3KooWD6sWeWCG5Z1qhejhkPk9Rob5h75wYmPB6MUoPo7br58m",
-		"/dns/bootnode-003.goldberg.avail.tools/tcp/30333/p2p/12D3KooWMR9ZoAVWJv6ahraVzUCfacNbFKk7ABoWxVL3fJ3XXGDw",
-		"/dns/bootnode-004.goldberg.avail.tools/tcp/30333/p2p/12D3KooWMuyLE3aPQ82HTWuPUCjiP764ebQrZvGUzxrYGuXWZJZV",
-		"/dns/bootnode-005.goldberg.avail.tools/tcp/30333/p2p/12D3KooWKJwbdcZ7QWcPLHy3EJ1UiffaLGnNBMffeK8AqRVWBZA1",
-		"/dns/bootnode-006.goldberg.avail.tools/tcp/30333/p2p/12D3KooWM8AaHDH8SJvg6bq4CGQyHvW2LH7DCHbdv633dsrti7i5",
+	// BootstrapPeersAvailTurin network extracted from:
+	//   https://raw.githubusercontent.com/availproject/avail/main/misc/genesis/testnet.turing.chain.spec.raw.json
+	BootstrapPeersAvailTurin = []string{
+		"/dns/bootnode-turing-001.avail.so/tcp/30333/p2p/12D3KooWRYCs192er73R2oyE4QWkKdtoRk1fL28tR3immzxTQQAq",
+		"/dns/bootnode-turing-002.avail.so/tcp/30333/p2p/12D3KooWLxzYHmGXpRnN4rAKkkZVzFgpGuqKofPggUnWz4iUR5yT",
+		"/dns/bootnode-turing-003.avail.so/tcp/30333/p2p/12D3KooWR8yPHmBZxHPoZrjjvCZEq5mJh9h7yewgM4zGgUVEANcG",
+		"/dns/bootnode-turing-004.avail.so/tcp/30333/p2p/12D3KooWKkLgiqxweQ1QCbJrDKeg5HCktZMM1kd81F4jMMTnBtD6",
+		"/dns/bootnode-turing-005.avail.so/tcp/30333/p2p/12D3KooWQRTgqX2j2HMideuPKUg12yeCbbp6cCi6xtf4cACYSiKb",
+		"/dns/bootnode-turing-006.avail.so/tcp/30333/p2p/12D3KooWPNmovc7n6mET56bmpB8tM6XtjcRb8qBir3sTBWk5cttK",
+		"/dns/bootnode-turing-007.avail.so/tcp/30333/p2p/12D3KooWFzqtue91MrdmqVRddA48dPYQVAFBtcFkf5HrmgiqUJ6F",
+		"/dns/bootnode-turing-008.avail.so/tcp/30333/p2p/12D3KooWMHRgZhDMUbN55NQcXB19Ww6SnL8shz1un3K6X3K2XoAh",
+		"/dns/bootnode-turing-009.avail.so/tcp/30333/p2p/12D3KooWQLdPYPEHRGAJ4J6dGYoiKyjm36VhaSCJkvKAuJBohJYi",
 	}
 
 	// BootstrapPeersPactusFullNode extracted from:

--- a/config/bootstrap.go
+++ b/config/bootstrap.go
@@ -229,9 +229,14 @@ var (
 		"enr:-Le4QLoE1wFHSlGcm48a9ZESb_MRLqPPu6G0vHqu4MaUcQNDHS69tsy-zkN0K6pglyzX8m24mkb-LtBcbjAYdP1uxm4BhGV0aDKQabfZdAQBcAAAAQAAAAAAAIJpZIJ2NIJpcIQ5gR6Wg2lwNpAgAUHQBwEQAAAAAAAAADR-iXNlY3AyNTZrMaEDPMSNdcL92uNIyCsS177Z6KTXlbZakQqxv3aQcWawNXeDdWRwgiMohHVkcDaCI4I",
 	}
 
+	//BootstrapPeersAvailTuringLightClient
+	BootstrapPeersAvailTuringLightClient = []string{
+		"/dns/bootnode.1.lightclient.turing.avail.so/tcp/37000/p2p/12D3KooWBkLsNGaD3SpMaRWtAmWVuiZg1afdNSPbtJ8M8r9ArGRT",
+	}
+
 	// BootstrapPeersAvailTurin network extracted from:
 	//   https://raw.githubusercontent.com/availproject/avail/main/misc/genesis/testnet.turing.chain.spec.raw.json
-	BootstrapPeersAvailTurin = []string{
+	BootstrapPeersAvailTuringFullNode = []string{
 		"/dns/bootnode-turing-001.avail.so/tcp/30333/p2p/12D3KooWRYCs192er73R2oyE4QWkKdtoRk1fL28tR3immzxTQQAq",
 		"/dns/bootnode-turing-002.avail.so/tcp/30333/p2p/12D3KooWLxzYHmGXpRnN4rAKkkZVzFgpGuqKofPggUnWz4iUR5yT",
 		"/dns/bootnode-turing-003.avail.so/tcp/30333/p2p/12D3KooWR8yPHmBZxHPoZrjjvCZEq5mJh9h7yewgM4zGgUVEANcG",

--- a/config/config.go
+++ b/config/config.go
@@ -34,8 +34,7 @@ const (
 	NetworkEthCons    Network = "ETHEREUM_CONSENSUS"
 	NetworkEthExec    Network = "ETHEREUM_EXECUTION"
 	NetworkHolesky    Network = "HOLESKY"
-	NetworkGoldbergLC Network = "GOLDBERG_LC"
-	NetworkGoldbergFN Network = "GOLDBERG_FN"
+	NetworkAvailTurin Network = "AVAIL_TURIN"
 	NetworkPactus     Network = "PACTUS"
 )
 
@@ -55,8 +54,7 @@ func Networks() []Network {
 		NetworkEthCons,
 		NetworkEthExec,
 		NetworkHolesky,
-		NetworkGoldbergLC,
-		NetworkGoldbergFN,
+		NetworkAvailTurin,
 		NetworkPactus,
 	}
 }
@@ -402,11 +400,8 @@ func ConfigureNetwork(network string) (*cli.StringSlice, *cli.StringSlice, error
 	case NetworkHolesky:
 		bootstrapPeers = cli.NewStringSlice(BootstrapPeersHolesky...)
 		protocols = cli.NewStringSlice("discv5") // TODO
-	case NetworkGoldbergLC:
-		bootstrapPeers = cli.NewStringSlice(BootstrapPeersGoldbergLightClient...)
-		protocols = cli.NewStringSlice("/avail_kad/id/1.0.0-6f0996")
-	case NetworkGoldbergFN:
-		bootstrapPeers = cli.NewStringSlice(BootstrapPeersGoldbergFullNode...)
+	case NetworkAvailTurin:
+		bootstrapPeers = cli.NewStringSlice(BootstrapPeersAvailTurin...)
 		protocols = cli.NewStringSlice("/Avail/kad")
 	case NetworkIPFS, NetworkAmino:
 		bps := []string{}

--- a/config/config.go
+++ b/config/config.go
@@ -20,22 +20,23 @@ import (
 type Network string
 
 const (
-	NetworkIPFS       Network = "IPFS"
-	NetworkAmino      Network = "AMINO"
-	NetworkFilecoin   Network = "FILECOIN"
-	NetworkKusama     Network = "KUSAMA"
-	NetworkPolkadot   Network = "POLKADOT"
-	NetworkRococo     Network = "ROCOCO"
-	NetworkWestend    Network = "WESTEND"
-	NetworkCelestia   Network = "CELESTIA"
-	NetworkArabica    Network = "ARABICA"
-	NetworkMocha      Network = "MOCHA"
-	NetworkBlockRa    Network = "BLOCKSPACE_RACE"
-	NetworkEthCons    Network = "ETHEREUM_CONSENSUS"
-	NetworkEthExec    Network = "ETHEREUM_EXECUTION"
-	NetworkHolesky    Network = "HOLESKY"
-	NetworkAvailTurin Network = "AVAIL_TURIN"
-	NetworkPactus     Network = "PACTUS"
+	NetworkIPFS          Network = "IPFS"
+	NetworkAmino         Network = "AMINO"
+	NetworkFilecoin      Network = "FILECOIN"
+	NetworkKusama        Network = "KUSAMA"
+	NetworkPolkadot      Network = "POLKADOT"
+	NetworkRococo        Network = "ROCOCO"
+	NetworkWestend       Network = "WESTEND"
+	NetworkCelestia      Network = "CELESTIA"
+	NetworkArabica       Network = "ARABICA"
+	NetworkMocha         Network = "MOCHA"
+	NetworkBlockRa       Network = "BLOCKSPACE_RACE"
+	NetworkEthCons       Network = "ETHEREUM_CONSENSUS"
+	NetworkEthExec       Network = "ETHEREUM_EXECUTION"
+	NetworkHolesky       Network = "HOLESKY"
+	NetworkAvailTuringLC Network = "AVAIL_TURING_LC"
+	NetworkAvailTuringFN Network = "AVAIL_TURING_FN"
+	NetworkPactus        Network = "PACTUS"
 )
 
 func Networks() []Network {
@@ -54,7 +55,8 @@ func Networks() []Network {
 		NetworkEthCons,
 		NetworkEthExec,
 		NetworkHolesky,
-		NetworkAvailTurin,
+		NetworkAvailTuringLC,
+		NetworkAvailTuringFN,
 		NetworkPactus,
 	}
 }
@@ -400,8 +402,11 @@ func ConfigureNetwork(network string) (*cli.StringSlice, *cli.StringSlice, error
 	case NetworkHolesky:
 		bootstrapPeers = cli.NewStringSlice(BootstrapPeersHolesky...)
 		protocols = cli.NewStringSlice("discv5") // TODO
-	case NetworkAvailTurin:
-		bootstrapPeers = cli.NewStringSlice(BootstrapPeersAvailTurin...)
+	case NetworkAvailTuringLC:
+		bootstrapPeers = cli.NewStringSlice(BootstrapPeersAvailTuringLightClient...)
+		protocols = cli.NewStringSlice("/avail_kad/id/1.0.0-6f0996")
+	case NetworkAvailTuringFN:
+		bootstrapPeers = cli.NewStringSlice(BootstrapPeersAvailTuringFullNode...)
 		protocols = cli.NewStringSlice("/Avail/kad")
 	case NetworkIPFS, NetworkAmino:
 		bps := []string{}

--- a/libp2p/driver_crawler.go
+++ b/libp2p/driver_crawler.go
@@ -108,7 +108,7 @@ func NewCrawlDriver(dbc db.Client, dbCrawl *models.Crawl, cfg *CrawlDriverConfig
 	// https://github.com/availproject/avail-light/blob/0ddc5d50d6f3d7217c448d6d008846c6b8c4fec3/src/network/p2p/event_loop.rs#L296
 	// Spoof it
 	userAgent := "nebula/" + cfg.Version
-	if cfg.Network == config.NetworkGoldbergLC {
+	if cfg.Network == config.NetworkAvailTurin {
 		userAgent = "avail-light-client/rust-client"
 	}
 

--- a/libp2p/driver_crawler.go
+++ b/libp2p/driver_crawler.go
@@ -108,7 +108,7 @@ func NewCrawlDriver(dbc db.Client, dbCrawl *models.Crawl, cfg *CrawlDriverConfig
 	// https://github.com/availproject/avail-light/blob/0ddc5d50d6f3d7217c448d6d008846c6b8c4fec3/src/network/p2p/event_loop.rs#L296
 	// Spoof it
 	userAgent := "nebula/" + cfg.Version
-	if cfg.Network == config.NetworkAvailTurin {
+	if cfg.Network == config.NetworkAvailTuringLC {
 		userAgent = "avail-light-client/rust-client"
 	}
 


### PR DESCRIPTION
# Description
Since the Avail Goldberg testnet has been deprecated, the bootnodes listed in [`./config/bootstrap.go](https://github.com/dennis-tra/nebula/blob/13c06a3e65a72c7b86e6120aaa856d711bf56d8a/config/bootstrap.go#L232) are outdated.

This PR aims to remove the deprecated bootnodes in favour of the new ones for the Avail Turin testnet ones.

*Works fine locally:*
```
$ nebula --dry-run crawl --network AVAIL_TURIN --limit 100
INFO[0000] Starting Nebula crawler...                   
INFO[0000] Queried 0 bootstrap peers                     limit=10
2024/07/01 15:56:40 failed to sufficiently increase receive buffer size (was: 208 kiB, wanted: 2048 kiB, got: 416 kiB). See https://github.com/quic-go/quic-go/wiki/UDP-Receive-Buffer-Size for details.
INFO[0000] Handled worker result                         crawlerID=crawler-04 duration=640.132682ms inflight=8 isDialable=true processed=1 queued=188 remoteID="<peer.ID 12*iqUJ6F>"
INFO[0000] Handled worker result                         crawlErr=stream_reset crawlerID=crawler-03 duration=744.947531ms inflight=195 isDialable=false processed=2 queued=165 remoteID="<peer.ID 12*k5cttK>"
INFO[0000] Handled worker result                         crawlErr=stream_reset crawlerID=crawler-24 duration=745.060788ms inflight=194 isDialable=false processed=3 queued=298 remoteID="<peer.ID 12*K2XoAh>"
INFO[0000] Handled worker result                         crawlerID=crawler-06 duration=807.585077ms inflight=491 isDialable=true processed=4 queued=110 remoteID="<peer.ID 12*xTQQAq>"
...
...
INFO[0002]                                              
INFO[0002] Finished crawl                                crawlDuration=2.020140179s crawledPeers=100 dialablePeers=93 undialablePeers=7
INFO[0002] Stopped Nebula crawler.
```