### PR TITLE
Add Avail Mainnet bootstrappers

### DIFF
--- a/config/bootstrap.go
+++ b/config/bootstrap.go
@@ -243,7 +243,10 @@ var (
 		"/dns/bootnode-mainnet-009.avail.so/tcp/30333/p2p/12D3KooWH1dPXxYyxwYjhbrjJ3PUJht9DyQkgdiJyiTtKVx5Voh4",
 		"/dns/bootnode-mainnet-010.avail.so/tcp/30333/p2p/12D3KooWLeXFyp1Ghm7oCt1EghhT39wnsNhZWT1jYEWTHn2pHU3E",
 	}
-	// TODO: add BootstrapPeersMainnetLightClient (unable to find link yet)
+	// BootstrapPeersAvailMainnetLightClient
+	BootstrapPeersAvailMainnetLightClient = []string{
+		"/dns/bootnode.1.lightclient.mainnet.avail.so/tcp/37000/p2p/12D3KooW9x9qnoXhkHAjdNFu92kMvBRSiFBMAoC5NnifgzXjsuiM",
+	}
 
 	//BootstrapPeersAvailTuringLightClient
 	BootstrapPeersAvailTuringLightClient = []string{

--- a/config/bootstrap.go
+++ b/config/bootstrap.go
@@ -229,6 +229,22 @@ var (
 		"enr:-Le4QLoE1wFHSlGcm48a9ZESb_MRLqPPu6G0vHqu4MaUcQNDHS69tsy-zkN0K6pglyzX8m24mkb-LtBcbjAYdP1uxm4BhGV0aDKQabfZdAQBcAAAAQAAAAAAAIJpZIJ2NIJpcIQ5gR6Wg2lwNpAgAUHQBwEQAAAAAAAAADR-iXNlY3AyNTZrMaEDPMSNdcL92uNIyCsS177Z6KTXlbZakQqxv3aQcWawNXeDdWRwgiMohHVkcDaCI4I",
 	}
 
+	// BootstrapPeersAvailMainnetFullNode extracted from:
+	// 	https://raw.githubusercontent.com/availproject/avail/main/misc/genesis/mainnet.chain.spec.json
+	BootstrapPeersAvailMainnetFullNode = []string{
+		"/dns/bootnode-mainnet-001.avail.so/tcp/30333/p2p/12D3KooWBXk3rcfKkvd1YbJ8fHPH4WZy34QCw8Czrvqf6cbmrdKh",
+		"/dns/bootnode-mainnet-002.avail.so/tcp/30333/p2p/12D3KooWMJt1z4ap2UacerW7vJprr7Mqws5sqmJXZqg8XpZswiwF",
+		"/dns/bootnode-mainnet-003.avail.so/tcp/30333/p2p/12D3KooWK85zotBy9jjgVhHzsvntAWWzRxTosF3RxwnJ9zJsGQbi",
+		"/dns/bootnode-mainnet-004.avail.so/tcp/30333/p2p/12D3KooWFyPvzGbTH7qbB3foBDDfwtn4LJsb4ryvTGGCokUyYDm7",
+		"/dns/bootnode-mainnet-005.avail.so/tcp/30333/p2p/12D3KooWFB6wBdwS1aacu3QZdmZb2sPDiVxP9iLFecLBiHKZELCX",
+		"/dns/bootnode-mainnet-006.avail.so/tcp/30333/p2p/12D3KooWLVJtN3hpUJYPjQzGKiHnbw6fpD5vvH5EkztdP1VAAgrj",
+		"/dns/bootnode-mainnet-007.avail.so/tcp/30333/p2p/12D3KooWPfsS6gAYoEiB8EaWbHdrbd6ugcru2kGguz56B9PxD4HT",
+		"/dns/bootnode-mainnet-008.avail.so/tcp/30333/p2p/12D3KooWSYiWfRCigRwWU9UzVJfZRz3SkCpYySH9w5ZydXUJWVuJ",
+		"/dns/bootnode-mainnet-009.avail.so/tcp/30333/p2p/12D3KooWH1dPXxYyxwYjhbrjJ3PUJht9DyQkgdiJyiTtKVx5Voh4",
+		"/dns/bootnode-mainnet-010.avail.so/tcp/30333/p2p/12D3KooWLeXFyp1Ghm7oCt1EghhT39wnsNhZWT1jYEWTHn2pHU3E",
+	}
+	// TODO: add BootstrapPeersMainnetLightClient (unable to find link yet)
+
 	//BootstrapPeersAvailTuringLightClient
 	BootstrapPeersAvailTuringLightClient = []string{
 		"/dns/bootnode.1.lightclient.turing.avail.so/tcp/37000/p2p/12D3KooWBkLsNGaD3SpMaRWtAmWVuiZg1afdNSPbtJ8M8r9ArGRT",

--- a/config/config.go
+++ b/config/config.go
@@ -35,10 +35,10 @@ const (
 	NetworkEthExec        Network = "ETHEREUM_EXECUTION"
 	NetworkHolesky        Network = "HOLESKY"
 	NetworkAvailMainnetFN Network = "AVAIL_MAINNET_FN"
-	// NetworkAvailMainnetLC Network = "AVAIL_MAINNET_LC" // TODO: missing bootnodes
-	NetworkAvailTuringLC Network = "AVAIL_TURING_LC"
-	NetworkAvailTuringFN Network = "AVAIL_TURING_FN"
-	NetworkPactus        Network = "PACTUS"
+	NetworkAvailMainnetLC Network = "AVAIL_MAINNET_LC"
+	NetworkAvailTuringLC  Network = "AVAIL_TURING_LC"
+	NetworkAvailTuringFN  Network = "AVAIL_TURING_FN"
+	NetworkPactus         Network = "PACTUS"
 )
 
 func Networks() []Network {
@@ -58,7 +58,7 @@ func Networks() []Network {
 		NetworkEthExec,
 		NetworkHolesky,
 		NetworkAvailMainnetFN,
-		// NetworkAvailMainnetLC, // TODO: missing bootnodes
+		NetworkAvailMainnetLC,
 		NetworkAvailTuringLC,
 		NetworkAvailTuringFN,
 		NetworkPactus,
@@ -409,9 +409,9 @@ func ConfigureNetwork(network string) (*cli.StringSlice, *cli.StringSlice, error
 	case NetworkAvailMainnetFN:
 		bootstrapPeers = cli.NewStringSlice(BootstrapPeersAvailMainnetFullNode...)
 		protocols = cli.NewStringSlice("/Avail/kad")
-	// case NetworkAvailMainnetLC:
-	// 	bootstrapPeers = cli.NewStringSlice(BootstrapPeersAvailMainnetLightClient...)
-	// 	protocols = cli.NewStringSlice("TODO")
+	case NetworkAvailMainnetLC:
+		bootstrapPeers = cli.NewStringSlice(BootstrapPeersAvailMainnetLightClient...)
+		protocols = cli.NewStringSlice("/avail_kad/id/1.0.0-b91746")
 	case NetworkAvailTuringLC:
 		bootstrapPeers = cli.NewStringSlice(BootstrapPeersAvailTuringLightClient...)
 		protocols = cli.NewStringSlice("/avail_kad/id/1.0.0-6f0996")

--- a/config/config.go
+++ b/config/config.go
@@ -20,20 +20,22 @@ import (
 type Network string
 
 const (
-	NetworkIPFS          Network = "IPFS"
-	NetworkAmino         Network = "AMINO"
-	NetworkFilecoin      Network = "FILECOIN"
-	NetworkKusama        Network = "KUSAMA"
-	NetworkPolkadot      Network = "POLKADOT"
-	NetworkRococo        Network = "ROCOCO"
-	NetworkWestend       Network = "WESTEND"
-	NetworkCelestia      Network = "CELESTIA"
-	NetworkArabica       Network = "ARABICA"
-	NetworkMocha         Network = "MOCHA"
-	NetworkBlockRa       Network = "BLOCKSPACE_RACE"
-	NetworkEthCons       Network = "ETHEREUM_CONSENSUS"
-	NetworkEthExec       Network = "ETHEREUM_EXECUTION"
-	NetworkHolesky       Network = "HOLESKY"
+	NetworkIPFS           Network = "IPFS"
+	NetworkAmino          Network = "AMINO"
+	NetworkFilecoin       Network = "FILECOIN"
+	NetworkKusama         Network = "KUSAMA"
+	NetworkPolkadot       Network = "POLKADOT"
+	NetworkRococo         Network = "ROCOCO"
+	NetworkWestend        Network = "WESTEND"
+	NetworkCelestia       Network = "CELESTIA"
+	NetworkArabica        Network = "ARABICA"
+	NetworkMocha          Network = "MOCHA"
+	NetworkBlockRa        Network = "BLOCKSPACE_RACE"
+	NetworkEthCons        Network = "ETHEREUM_CONSENSUS"
+	NetworkEthExec        Network = "ETHEREUM_EXECUTION"
+	NetworkHolesky        Network = "HOLESKY"
+	NetworkAvailMainnetFN Network = "AVAIL_MAINNET_FN"
+	// NetworkAvailMainnetLC Network = "AVAIL_MAINNET_LC" // TODO: missing bootnodes
 	NetworkAvailTuringLC Network = "AVAIL_TURING_LC"
 	NetworkAvailTuringFN Network = "AVAIL_TURING_FN"
 	NetworkPactus        Network = "PACTUS"
@@ -55,6 +57,8 @@ func Networks() []Network {
 		NetworkEthCons,
 		NetworkEthExec,
 		NetworkHolesky,
+		NetworkAvailMainnetFN,
+		// NetworkAvailMainnetLC, // TODO: missing bootnodes
 		NetworkAvailTuringLC,
 		NetworkAvailTuringFN,
 		NetworkPactus,
@@ -402,6 +406,12 @@ func ConfigureNetwork(network string) (*cli.StringSlice, *cli.StringSlice, error
 	case NetworkHolesky:
 		bootstrapPeers = cli.NewStringSlice(BootstrapPeersHolesky...)
 		protocols = cli.NewStringSlice("discv5") // TODO
+	case NetworkAvailMainnetFN:
+		bootstrapPeers = cli.NewStringSlice(BootstrapPeersAvailMainnetFullNode...)
+		protocols = cli.NewStringSlice("/Avail/kad")
+	// case NetworkAvailMainnetLC:
+	// 	bootstrapPeers = cli.NewStringSlice(BootstrapPeersAvailMainnetLightClient...)
+	// 	protocols = cli.NewStringSlice("TODO")
 	case NetworkAvailTuringLC:
 		bootstrapPeers = cli.NewStringSlice(BootstrapPeersAvailTuringLightClient...)
 		protocols = cli.NewStringSlice("/avail_kad/id/1.0.0-6f0996")

--- a/libp2p/driver_crawler.go
+++ b/libp2p/driver_crawler.go
@@ -108,9 +108,7 @@ func NewCrawlDriver(dbc db.Client, dbCrawl *models.Crawl, cfg *CrawlDriverConfig
 	// https://github.com/availproject/avail-light/blob/0ddc5d50d6f3d7217c448d6d008846c6b8c4fec3/src/network/p2p/event_loop.rs#L296
 	// Spoof it
 	userAgent := "nebula/" + cfg.Version
-	if cfg.Network == config.NetworkAvailTuringLC ||
-		cfg.Network == config.NetworkAvailTuringFN ||
-		cfg.Network == config.NetworkAvailMainnetFN {
+	if cfg.Network == config.NetworkAvailTuringLC || cfg.Network == config.NetworkAvailMainnetLC {
 		userAgent = "avail-light-client/rust-client"
 	}
 

--- a/libp2p/driver_crawler.go
+++ b/libp2p/driver_crawler.go
@@ -108,7 +108,9 @@ func NewCrawlDriver(dbc db.Client, dbCrawl *models.Crawl, cfg *CrawlDriverConfig
 	// https://github.com/availproject/avail-light/blob/0ddc5d50d6f3d7217c448d6d008846c6b8c4fec3/src/network/p2p/event_loop.rs#L296
 	// Spoof it
 	userAgent := "nebula/" + cfg.Version
-	if cfg.Network == config.NetworkAvailTuringLC {
+	if cfg.Network == config.NetworkAvailTuringLC ||
+		cfg.Network == config.NetworkAvailTuringFN ||
+		cfg.Network == config.NetworkAvailMainnetFN {
 		userAgent = "avail-light-client/rust-client"
 	}
 


### PR DESCRIPTION
# Description
last week, Avail launched their mainnet officially. In order to set up Nebula to run in that network as well, we need to add support for both: the `AVAIL_MAINNET_FN` and `AVAIL_MAINNET_LC` networks.

# Tasks:
- [x] Add new bootstrapers for `AVAIL_MAINNET_FN`
- [x] Add new bootstrapers for `AVAIL_MAINNET_LC`
- [x] Update the networks that use the `avail-light-client/rust-client` user agent 