### PR TITLE
Introduce deduplication key

### DIFF
--- a/cmd/nebula/cmd_crawl.go
+++ b/cmd/nebula/cmd_crawl.go
@@ -211,7 +211,7 @@ func CrawlAction(c *cli.Context) error {
 		return fmt.Errorf("new database client: %w", err)
 	}
 	defer func() {
-		if err := dbc.Close(); err != nil && !errors.Is(err, sql.ErrConnDone) {
+		if err := dbc.Close(); err != nil && !errors.Is(err, sql.ErrConnDone) && !strings.Contains(err.Error(), "use of closed network connection") {
 			log.WithError(err).Warnln("Failed closing database handle")
 		}
 	}()

--- a/core/core.go
+++ b/core/core.go
@@ -23,6 +23,16 @@ type PeerInfo[T any] interface {
 	// peer info struct. The implementation of Merge may panic if the peer IDs
 	// don't match.
 	Merge(other T) T
+
+	// DeduplicationKey returns a unique string used for deduplication of crawl
+	// tasks. For example, in discv4 and discv5 we might want to crawl the same
+	// peer (as identified by its public key) multiple times when we find new
+	// ENR's for it. If the deduplication key was just the public key, we would
+	// only crawl it once. If we later find newer ENR's for the same peer with
+	// different network addresses, we would skip that peer. On the other hand,
+	// if the deduplication key was the entire ENR, we would crawl the same peer
+	// with different (potentially newer) connectivity information again.
+	DeduplicationKey() string
 }
 
 // A Driver is a data structure that provides the necessary implementations and

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -27,6 +27,10 @@ type testPeerInfo struct {
 	addrs  []ma.Multiaddr
 }
 
+func (p *testPeerInfo) DeduplicationKey() string {
+	return string(p.peerID)
+}
+
 var _ PeerInfo[*testPeerInfo] = (*testPeerInfo)(nil)
 
 func (p *testPeerInfo) Addrs() []ma.Multiaddr {

--- a/core/engine.go
+++ b/core/engine.go
@@ -279,11 +279,11 @@ func (e *Engine[I, R]) Run(ctx context.Context) (map[string]I, error) {
 			observeFn(e)
 		case innerPeerTasks <- peerTask:
 			// a worker was ready to accept a new task -> perform internal bookkeeping.
-			e.peerQueue.Drop(string(peerTask.ID()))
-			e.inflight[string(peerTask.ID())] = struct{}{}
+			e.peerQueue.Drop(peerTask.DeduplicationKey())
+			e.inflight[peerTask.DeduplicationKey()] = struct{}{}
 		case innerWriteTasks <- writeTask:
 			// a write worker was ready to accept a new task -> perform internal bookkeeping.
-			e.writeQueue.Drop(string(writeTask.PeerInfo().ID()))
+			e.writeQueue.Drop(writeTask.PeerInfo().DeduplicationKey())
 		case result, more := <-peerResults:
 			if !more {
 				// the peerResults queue was closed. This means all workers
@@ -366,19 +366,22 @@ func (e *Engine[I, R]) handlePeerResult(ctx context.Context, result Result[R]) {
 	// count the number of visits being made
 	e.telemetry.visitCount.Add(ctx, 1, metric.WithAttributes(attribute.Bool("success", result.Value.IsSuccess())))
 
+	// get hold of the deduplication key
+	key := wr.PeerInfo().DeduplicationKey()
+
 	// The operation for this peer is not inflight anymore -> delete it.
-	delete(e.inflight, string(wr.PeerInfo().ID()))
+	delete(e.inflight, key)
 
 	// Keep track that this peer was processed, so we don't do it again during
 	// this run. Unless we explicitly allow duplicate processing.
 	if !e.cfg.DuplicateProcessing {
-		e.processed[string(wr.PeerInfo().ID())] = struct{}{}
+		e.processed[key] = struct{}{}
 		logEntry = logEntry.WithField("processed", len(e.processed))
 	}
 
 	// Publish the processing result to the writer queue so that the data is
 	// saved to disk.
-	e.writeQueue.Push(string(wr.PeerInfo().ID()), wr, 0)
+	e.writeQueue.Push(key, wr, 0)
 
 	// let the handler work on the new peer result
 	newTasks := e.handler.HandlePeerResult(ctx, result)
@@ -413,21 +416,25 @@ func (e *Engine[I, R]) handleWriteResult(ctx context.Context, result Result[Writ
 }
 
 func (e *Engine[I, R]) enqueueTask(task I) {
-	mapKey := string(task.ID())
+	key := task.DeduplicationKey()
 
 	// Don't add this peer to the queue if we're currently querying it
-	if _, isInflight := e.inflight[mapKey]; isInflight {
+	if _, isInflight := e.inflight[key]; isInflight {
 		return
 	}
 
 	// Don't add the peer to the queue if we have already processed it
-	if _, processed := e.processed[mapKey]; processed {
+	// Note: we handle the DuplicateProcessing logic when Nebula runs
+	// in monitoring mode on the side where we populate this `processed`
+	// map. If we handled it here and still kept track of all processed
+	// peers, we would have a memory leak.
+	if _, processed := e.processed[key]; processed {
 		return
 	}
 
 	// Check if we have already queued this peer. If so, merge the new
 	// information with the already existing ones.
-	queuedTask, isQueued := e.peerQueue.Find(mapKey)
+	queuedTask, isQueued := e.peerQueue.Find(key)
 	if isQueued {
 		task = task.Merge(queuedTask)
 	}
@@ -445,9 +452,9 @@ func (e *Engine[I, R]) enqueueTask(task I) {
 	// If the peer was already queued we only update its priority. If the
 	// peer wasn't queued, we push it to the queue.
 	if isQueued {
-		e.peerQueue.Update(mapKey, task, priority)
+		e.peerQueue.Update(key, task, priority)
 	} else {
-		e.peerQueue.Push(mapKey, task, priority)
+		e.peerQueue.Push(key, task, priority)
 	}
 }
 

--- a/discv4/driver_crawler.go
+++ b/discv4/driver_crawler.go
@@ -114,6 +114,10 @@ func (p PeerInfo) Merge(other PeerInfo) PeerInfo {
 	return p
 }
 
+func (p PeerInfo) DeduplicationKey() string {
+	return p.Node.String()
+}
+
 type CrawlDriverConfig struct {
 	Version          string
 	TrackNeighbors   bool

--- a/discv5/driver_crawler.go
+++ b/discv5/driver_crawler.go
@@ -129,6 +129,13 @@ func (p PeerInfo) Merge(other PeerInfo) PeerInfo {
 	return p
 }
 
+func (p PeerInfo) DeduplicationKey() string {
+	// TODO: this should probably be p.Node.String() but a change here needs to
+	// be coordinated with changes to our analysis scripts, so I'm keeping it as
+	// it is.
+	return string(p.peerID)
+}
+
 type CrawlDriverConfig struct {
 	Version        string
 	TrackNeighbors bool

--- a/go.mod
+++ b/go.mod
@@ -216,7 +216,7 @@ replace (
 	// replace go-ethereum with fork (branch  nebula). Changes:
 	// - move everything inside the devp2p/internal package into devp2p to make it accessible
 	// - add Identify method
-	github.com/ethereum/go-ethereum => github.com/probe-lab/go-ethereum v0.0.0-20241022142913-055893677af7
+	github.com/ethereum/go-ethereum => github.com/probe-lab/go-ethereum v0.0.0-20241022152419-a32e9b25a50e
 
 	// replace go-libp2p with fork (branch  v0.28.3-nebula). Changes:
 	// - avoid running into dial backoffs even if forceDirectDial is set to false

--- a/go.sum
+++ b/go.sum
@@ -766,8 +766,8 @@ github.com/polydawn/refmt v0.89.0 h1:ADJTApkvkeBZsN0tBTx8QjpD9JkmxbKp0cxfr9qszm4
 github.com/polydawn/refmt v0.89.0/go.mod h1:/zvteZs/GwLtCgZ4BL6CBsk9IKIlexP43ObX9AxTqTw=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/probe-lab/go-ethereum v0.0.0-20241022142913-055893677af7 h1:jTSzh+vCEYzYXnA6/KbfRWAiNxnnxyR9C4jPXrUvKoI=
-github.com/probe-lab/go-ethereum v0.0.0-20241022142913-055893677af7/go.mod h1:+l/fr42Mma+xBnhefL/+z11/hcmJ2egl+ScIVPjhc7E=
+github.com/probe-lab/go-ethereum v0.0.0-20241022152419-a32e9b25a50e h1:12D0oiC4KT4N3gySv3gSjVTDOsTMu0N6kbfeMe8Nx+0=
+github.com/probe-lab/go-ethereum v0.0.0-20241022152419-a32e9b25a50e/go.mod h1:+l/fr42Mma+xBnhefL/+z11/hcmJ2egl+ScIVPjhc7E=
 github.com/probe-lab/go-libp2p v0.36.6-0.20241010102656-740d456bfc63 h1:Zn3+Q7EuwGCNEU7Xtk0hItXLwkStZP8zaPrDcUQSkmQ=
 github.com/probe-lab/go-libp2p v0.36.6-0.20241010102656-740d456bfc63/go.mod h1:CpszAtXxHYOcyvB7K8rSHgnNlh21eKjYbEfLoMerbEI=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/libp2p/driver_crawler.go
+++ b/libp2p/driver_crawler.go
@@ -60,6 +60,10 @@ func (p PeerInfo) Merge(other PeerInfo) PeerInfo {
 	}
 }
 
+func (p PeerInfo) DeduplicationKey() string {
+	return string(p.AddrInfo.ID)
+}
+
 type CrawlDriverConfig struct {
 	Version        string
 	Network        config.Network

--- a/libp2p/driver_crawler.go
+++ b/libp2p/driver_crawler.go
@@ -61,7 +61,7 @@ func (p PeerInfo) Merge(other PeerInfo) PeerInfo {
 }
 
 func (p PeerInfo) DeduplicationKey() string {
-	return string(p.AddrInfo.ID)
+	return p.AddrInfo.ID.String()
 }
 
 type CrawlDriverConfig struct {


### PR DESCRIPTION
This PR introduces the concept of deduplication keys.

A deduplication key is a unique string used for deduplication of crawl tasks. For example, in discv4 and discv5 we might want to crawl the same peer (as identified by its public key) multiple times when we find new ENR's for it. If the deduplication key was just the public key, we would only crawl it only once. If we later find newer ENR's for the same peer with different network addresses, we would skip that peer. On the other hand, if the deduplication key was the entire ENR, we would crawl the same peer with different (potentially newer) connectivity information again.