### PR TITLE
fix: attnets decoding out of bound exception

### DIFF
--- a/discv5/enr.go
+++ b/discv5/enr.go
@@ -138,6 +138,8 @@ func (e *ENREntryAttnets) DecodeRLP(s *rlp.Stream) error {
 	b, err := s.Bytes()
 	if err != nil {
 		return fmt.Errorf("failed to get bytes for attnets ENR entry: %w", err)
+	} else if len(b) != 8 {
+		return fmt.Errorf("attnets ENR entry must be 8 bytes long, got %d", len(b))
 	}
 
 	e.AttnetsNum = bits.OnesCount64(binary.BigEndian.Uint64(b))


### PR DESCRIPTION
We observed the following out of bounds exception:


```text
panic: runtime error: index out of range [7] with length 5 goroutine 14309 [running]:
encoding/binary.bigEndian.Uint64(...)
	/usr/local/go/src/encoding/binary/binary.go:186
github.com/dennis-tra/nebula-crawler/discv5.(*ENREntryAttnets).DecodeRLP(0xc02749eee8, 0x1f2de20?)
	/build/discv5/enr.go:143 +0x1a9
github.com/ethereum/go-ethereum/rlp.decodeDecoder(0xc00e0e1c70, {0x1fd6480?, 0xc02749eee8?, 0xc03af70990?})
	/go/pkg/mod/github.com/probe-lab/go-ethereum@v0.0.0-20241105111838-95c73e73f0fd/rlp/decode.go:542 +0x96
github.com/ethereum/go-ethereum/rlp.(*Stream).Decode(0xc00e0e1c70, {0x1f2de20?, 0xc02749eee8?})
	/go/pkg/mod/github.com/probe-lab/go-ethereum@v0.0.0-20241105111838-95c73e73f0fd/rlp/decode.go:950 +0x1f0
github.com/ethereum/go-ethereum/rlp.DecodeBytes({0xc013c91060, 0x6, 0x6}, {0x1f2de20, 0xc02749eee8})
	/go/pkg/mod/github.com/probe-lab/go-ethereum@v0.0.0-20241105111838-95c73e73f0fd/rlp/decode.go:99 +0x11f
github.com/ethereum/go-ethereum/p2p/enr.(*Record).Load(0xc010bb6090, {0x29c3280, 0xc02749eee8})
	/go/pkg/mod/github.com/probe-lab/go-ethereum@v0.0.0-20241105111838-95c73e73f0fd/p2p/enr/enr.go:139 +0x131
github.com/ethereum/go-ethereum/p2p/enode.(*Node).Load(...)
	/go/pkg/mod/github.com/probe-lab/go-ethereum@v0.0.0-20241105111838-95c73e73f0fd/p2p/enode/node.go:164
github.com/dennis-tra/nebula-crawler/discv5.(*Crawler).PeerProperties(0xc00756ccc0, 0xc010bb6090)
	/build/discv5/crawler.go:218 +0x3b8
github.com/dennis-tra/nebula-crawler/discv5.(*Crawler).Work(_, {_, _}, {0xc010bb6090, {0xc003032c30, 0x27}, {0xc024dee318, 0x1, 0x1}, {0xc0101391d0, ...}, ...})
	/build/discv5/crawler.go:87 +0x568
github.com/dennis-tra/nebula-crawler/core.(*Pool[...]).Start.func1.1()
	/build/core/worker.go:34 +0x1ba
created by github.com/dennis-tra/nebula-crawler/core.(*Pool[...]).Start.func1 in goroutine 1
	/build/core/worker.go:32 +0x8e
```