### PR TITLE
README.md: Clarify that Clickhouse TCP is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Currently, Nebula supports the following networks:
 
 You can run `nebula networks` to get a list of all supported networks
 
-Nebula supports the following storage backends: JSON, Postgres, ClickHouse
+Nebula supports the following storage backends: JSON, Postgres, ClickHouse ([TCP](https://clickhouse.com/docs/interfaces/tcp) protocol)
 
 
 The crawler was:


### PR DESCRIPTION
which is different from Clickhouse HTTP & Clickhouse gRPC, see https://clickhouse.com/docs/interfaces/tcp

I inferred that nebula only supports Clickhouse TCP from the fact that I cannot use it on my Clickhouse instance with TCP port 9000 blocked, and that nebula uses 9000 as its default port for Clickhouse DBs, which use that port for TCP by default ([src](https://clickhouse.com/docs/guides/sre/network-ports)).